### PR TITLE
feat: declarative interactivity suppression (data-hc-suppress) + interactivity module consolidation

### DIFF
--- a/docs/brainstorms/2026-06-26-declarative-interactivity-suppression.md
+++ b/docs/brainstorms/2026-06-26-declarative-interactivity-suppression.md
@@ -38,12 +38,11 @@ because the visual reads the DOM itself — no author scripting required.
 
 ## The contract
 
-Two `data-` attributes:
+One `data-` attribute:
 
 | Attribute | Effect |
 |---|---|
 | `data-hc-suppress="filter context-menu tooltip"` | Disable the named interactions for this node **and its descendants** |
-| `data-hc-force="filter"` | Re-enable a named interaction that an ancestor suppressed |
 
 **Tokens** (space-separated):
 
@@ -55,19 +54,12 @@ Two `data-` attributes:
 Unknown tokens are ignored (forward-compatible: new interaction types can be
 added later without breaking older markup).
 
-### Resolution — nearest-ancestor-wins, per token
+### Resolution — any suppressing ancestor wins, per token
 
 For a given event and token, walk from the event's target up the parent chain.
-The first element that names the token decides it:
-
-- named via `data-hc-force` → **on**
-- named via `data-hc-suppress` → **off**
-- same element names it in both → **`force` wins**
-- no ancestor names it → **on** (today's default behaviour, unchanged)
-
-`all` is expanded to its constituent tokens before this walk, so a child's
-`data-hc-force="filter"` cleanly re-enables one interaction under an ancestor's
-`data-hc-suppress="all"`.
+If any element names that token in `data-hc-suppress` → **off**; if none do →
+**on** (today's default behaviour, unchanged). `all` expands to its constituent
+tokens before the walk.
 
 No boundary tracking is needed: `hc-` tokens only ever exist inside author
 content, so walking to the document root is safe and simpler than tracking the
@@ -88,6 +80,10 @@ resolveInteractivity(node: Element | null, token: InteractionToken): boolean
 
 Attribute and token strings live in `VisualConstants.dom`.
 
+The tooltip path calls this on `mousemove`, so it walks the parent chain per
+move. Fine at normal DOM depth (one attribute read per node); leave a
+`// ponytail:` note and only memoise if a profiler on multi-MB content complains.
+
 ### Wiring into existing handlers (no new event bindings)
 
 - **`behavior.ts` `bindClick`** — if `filter` resolves off for `event.target`:
@@ -96,7 +92,8 @@ Attribute and token strings live in `VisualConstants.dom`.
 - **`behavior.ts` `bindClearCatcher`** — if `filter` is off for the target: skip
   the clear.
 - **`behavior.ts` `bindContextMenu`** (row + clear-catcher) — if `context-menu`
-  is off: return without our `preventDefault` / menu (native behaviour applies).
+  is off: `event.preventDefault()` and return, so **no menu shows** (neither our
+  drill menu nor the browser's native one). Suppression means "nothing here".
 - **`domain-utils.ts` `bindStandardTooltips`** — if `tooltip` is off:
   `tooltipService.hide(...)` and return instead of showing.
 - **`domain-utils.ts` `bindManualTooltips`** — same check before showing a manual
@@ -110,31 +107,32 @@ resolver and is unaffected.
 
 Both `Team Card Body Template` and `Team Card Content`:
 
-- `modal-overlay` gets `data-hc-suppress='all'` — a fully inert backdrop.
-- One inner control gets `data-hc-force='filter'` (e.g. a "Filter to this person"
-  button), proving and documenting the override path with a real consumer.
+- `modal-overlay` gets `data-hc-suppress='all'` — a fully inert backdrop. This is
+  the end-to-end proof of the feature against the original reviewer complaint.
 
 ## Documentation
 
-- Document both attributes, the token vocabulary, and the resolution rule in
+- Document the attribute, the token vocabulary, and the resolution rule in
   `docs/v2/HTML-Content-v2-Guide.md`.
 - Mirror into `docs/v2/scripting-unsanitized-edition.md` where relevant, noting
   this is the declarative replacement for hand-written `stopPropagation()`.
 
 ## Testing
 
-- Unit tests for `resolveInteractivity`: single suppress, force override, `all`
-  expansion, nested suppress→force→suppress, unknown-token ignore, default-on.
+- Unit tests for `resolveInteractivity`: single suppress, `all` expansion, nested
+  suppress, unknown-token ignore, default-on.
 - `behavior.test.ts`: click on a suppressed subtree does not toggle and does not
-  clear; `force='filter'` inside a suppressed subtree does toggle; `context-menu`
-  suppression skips the menu.
+  clear; `context-menu` suppression shows no menu (and calls `preventDefault`).
 - Tooltip tests: hover over a `tooltip`-suppressed subtree hides rather than shows.
 
 ## Out of scope (YAGNI)
 
+- **`data-hc-force` (re-enable under a suppressing ancestor)** — deferred: no real
+  consumer today. The resolver stays a cheap upgrade away (the parent-chain walk
+  would compare nearest `suppress` vs `force` instead of first-suppress-wins). Add
+  when a real layout needs to punch a hole in a suppressed region.
 - Restructuring modals out of the row subtree (a shared modal + JS repopulation) —
   the marker makes it unnecessary.
-- A JavaScript opt-in API — the declarative attributes cover the need and work in
+- A JavaScript opt-in API — the declarative attribute covers the need and works in
   the certified edition.
 - Per-token suppression of hyperlinks — separate concern, not requested.
-- Any inheritance model beyond the suppress/force pair.

--- a/docs/brainstorms/2026-06-26-declarative-interactivity-suppression.md
+++ b/docs/brainstorms/2026-06-26-declarative-interactivity-suppression.md
@@ -105,17 +105,25 @@ resolver and is unaffected.
 
 ## Sample report changes
 
+The sample lives in `sample-for-templates/`, which is **untracked UAT scratch**
+(too data-heavy to be a permanent corpus) and stays untracked. We edit it locally
+to prove the feature; it is not committed.
+
 Both `Team Card Body Template` and `Team Card Content`:
 
 - `modal-overlay` gets `data-hc-suppress='all'` — a fully inert backdrop. This is
   the end-to-end proof of the feature against the original reviewer complaint.
 
+**Follow-up (not this work):** build a lighter, committable UAT corpus that
+exercises `data-hc-suppress` without the Team Cards sample's data weight, so the
+feature has a permanent regression fixture.
+
 ## Documentation
 
-- Document the attribute, the token vocabulary, and the resolution rule in
-  `docs/v2/HTML-Content-v2-Guide.md`.
-- Mirror into `docs/v2/scripting-unsanitized-edition.md` where relevant, noting
-  this is the declarative replacement for hand-written `stopPropagation()`.
+Author-facing documentation (the attribute, token vocabulary, resolution rule,
+and that it is the declarative replacement for hand-written `stopPropagation()`)
+is maintained separately by the maintainer in the untracked v2 author guide. Not
+part of the implementation plan, and not referenced from code or commits.
 
 ## Testing
 

--- a/docs/brainstorms/2026-06-26-declarative-interactivity-suppression.md
+++ b/docs/brainstorms/2026-06-26-declarative-interactivity-suppression.md
@@ -1,0 +1,140 @@
+# Declarative interactivity suppression
+
+**Date:** 2026-06-26
+**Status:** Approved (design) — pending implementation plan
+**Issue context:** Reviewer feedback on the Team Cards sample (issue #127 / PR #164)
+
+## Problem
+
+The Team Cards sample renders a per-row modal dialog inside each employee card.
+A reviewer reported two behaviours, both traced to one structural fact:
+
+In `Team Card Content` the modal is concatenated **inside** the `emp-card`
+element, and the card *is* the visual's data-point element (`behavior.ts` binds
+click / contextmenu / tooltip on each row root via `pointSelection`). One modal
+per row, nested in the card.
+
+- **Cross-filter on modal click** — a click inside the modal bubbles to the
+  card's click handler and toggles that card's selection. (`stopPropagation` in
+  `handleSelectionClick` is why it toggles rather than clears.)
+- **Tooltip over the modal** — `mouseover` is bound on the same card root
+  (`bindStandardTooltips`), so hovering the modal shows the card's tooltip; the
+  underlying card sitting directly beneath compounds it. (The "highlights a row"
+  effect is Power BI's native tooltip and is out of our control — but removing
+  *our* tooltip over the modal removes the trigger.)
+
+The reviewer's instinct — "I didn't expect a non-clickable thing to cause
+cross-filter" — is correct: the modal is structurally part of a clickable data
+point. The current workaround is to hand-write `event.stopPropagation()` in JS,
+which is unavailable in the certified (no-scripting) edition and clumsy in the
+unsanitised one.
+
+## Goal
+
+A declarative, markup-only way to mark a node and its descendants as inert to the
+visual's delegated interactivity (cross-filter, context menu, tooltip), deferring
+to the author's own and the browser's native behaviour. Works in both editions
+because the visual reads the DOM itself — no author scripting required.
+
+## The contract
+
+Two `data-` attributes:
+
+| Attribute | Effect |
+|---|---|
+| `data-hc-suppress="filter context-menu tooltip"` | Disable the named interactions for this node **and its descendants** |
+| `data-hc-force="filter"` | Re-enable a named interaction that an ancestor suppressed |
+
+**Tokens** (space-separated):
+
+- `filter` — cross-filter: both select-toggle and clear.
+- `context-menu` — right-click context / drill menu.
+- `tooltip` — hover tooltip (standard contextual **and** manual `tooltipEnabled`).
+- `all` — expands to the three tokens above before resolution.
+
+Unknown tokens are ignored (forward-compatible: new interaction types can be
+added later without breaking older markup).
+
+### Resolution — nearest-ancestor-wins, per token
+
+For a given event and token, walk from the event's target up the parent chain.
+The first element that names the token decides it:
+
+- named via `data-hc-force` → **on**
+- named via `data-hc-suppress` → **off**
+- same element names it in both → **`force` wins**
+- no ancestor names it → **on** (today's default behaviour, unchanged)
+
+`all` is expanded to its constituent tokens before this walk, so a child's
+`data-hc-force="filter"` cleanly re-enables one interaction under an ancestor's
+`data-hc-suppress="all"`.
+
+No boundary tracking is needed: `hc-` tokens only ever exist inside author
+content, so walking to the document root is safe and simpler than tracking the
+bound `currentTarget`.
+
+## Implementation
+
+### New module — `src/interactivity-policy.ts`
+
+A single pure function plus token parsing. This is the only genuinely new logic.
+
+```ts
+type InteractionToken = 'filter' | 'context-menu' | 'tooltip';
+
+// true = interaction allowed (default), false = suppressed
+resolveInteractivity(node: Element | null, token: InteractionToken): boolean
+```
+
+Attribute and token strings live in `VisualConstants.dom`.
+
+### Wiring into existing handlers (no new event bindings)
+
+- **`behavior.ts` `bindClick`** — if `filter` resolves off for `event.target`:
+  `event.stopPropagation()` (so it does not fall through to the clear-catcher)
+  and return; otherwise the existing toggle.
+- **`behavior.ts` `bindClearCatcher`** — if `filter` is off for the target: skip
+  the clear.
+- **`behavior.ts` `bindContextMenu`** (row + clear-catcher) — if `context-menu`
+  is off: return without our `preventDefault` / menu (native behaviour applies).
+- **`domain-utils.ts` `bindStandardTooltips`** — if `tooltip` is off:
+  `tooltipService.hide(...)` and return instead of showing.
+- **`domain-utils.ts` `bindManualTooltips`** — same check before showing a manual
+  tooltip.
+
+Authors' own inner handlers (the close ✕'s `onclick`, task-link `href`) are
+untouched — we only skip *our* delegated logic. Hyperlink handling is a separate
+resolver and is unaffected.
+
+## Sample report changes
+
+Both `Team Card Body Template` and `Team Card Content`:
+
+- `modal-overlay` gets `data-hc-suppress='all'` — a fully inert backdrop.
+- One inner control gets `data-hc-force='filter'` (e.g. a "Filter to this person"
+  button), proving and documenting the override path with a real consumer.
+
+## Documentation
+
+- Document both attributes, the token vocabulary, and the resolution rule in
+  `docs/v2/HTML-Content-v2-Guide.md`.
+- Mirror into `docs/v2/scripting-unsanitized-edition.md` where relevant, noting
+  this is the declarative replacement for hand-written `stopPropagation()`.
+
+## Testing
+
+- Unit tests for `resolveInteractivity`: single suppress, force override, `all`
+  expansion, nested suppress→force→suppress, unknown-token ignore, default-on.
+- `behavior.test.ts`: click on a suppressed subtree does not toggle and does not
+  clear; `force='filter'` inside a suppressed subtree does toggle; `context-menu`
+  suppression skips the menu.
+- Tooltip tests: hover over a `tooltip`-suppressed subtree hides rather than shows.
+
+## Out of scope (YAGNI)
+
+- Restructuring modals out of the row subtree (a shared modal + JS repopulation) —
+  the marker makes it unnecessary.
+- A JavaScript opt-in API — the declarative attributes cover the need and work in
+  the certified edition.
+- Per-token suppression of hyperlinks — separate concern, not requested.
+- Any inheritance model beyond the suppress/force pair.

--- a/docs/plans/2026-06-26-001-declarative-interactivity-suppression-plan.md
+++ b/docs/plans/2026-06-26-001-declarative-interactivity-suppression-plan.md
@@ -1,0 +1,898 @@
+# Declarative Interactivity Suppression Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let report authors mark a DOM node (and its descendants) inert to the visual's cross-filter, context-menu, and tooltip handling via a `data-hc-suppress` markup attribute — and land it on a consolidated `src/interactivity/` surface, extracting the interactivity code currently scattered across `behavior.ts` and the `domain-utils.ts` grab-bag.
+
+**Architecture:** Two phases. **Phase A** consolidates the existing interactivity API into `src/interactivity/` (behavior, tooltips, hyperlinks) — behavior-preserving moves, suite green after each. **Phase B** adds the new `resolveInteractivity` resolver and wires the existing delegated handlers to bail out early when an ancestor carries `data-hc-suppress`; the sample report marks its modal overlay as the end-to-end proof.
+
+**Tech Stack:** TypeScript, d3-selection, Power BI visuals API, Vitest (jsdom), DAX/TMDL (sample measures).
+
+**Spec:** `docs/brainstorms/2026-06-26-declarative-interactivity-suppression.md`
+
+---
+
+## File structure
+
+**Target `src/interactivity/`:**
+
+| File | Responsibility | Origin |
+|---|---|---|
+| `src/interactivity/index.ts` | Barrel — the public interactivity surface | New |
+| `src/interactivity/behavior.ts` | `BehaviorManager`, `IHtmlBehaviorOptions` | Moved from `src/behavior.ts` |
+| `src/interactivity/tooltips.ts` | `resolveHover` (+ standard/manual binders) | Extracted from `domain-utils.ts` |
+| `src/interactivity/hyperlinks.ts` | `resolveHyperlinkHandling` | Extracted from `domain-utils.ts` |
+| `src/interactivity/policy.ts` | `resolveInteractivity`, `InteractionToken` | New (the feature) |
+
+**Other changes:**
+
+| File | Change |
+|---|---|
+| `src/visual-constants.ts` | Add `suppressAttr` / `suppressAllToken` to the `dom` block |
+| `src/visual.ts` | Repoint interactivity imports to `./interactivity` |
+| `src/domain-utils.ts` | Remove the extracted functions + their now-unused diagnostics imports |
+| `test/behavior.test.ts` | Repoint import; add suppression tests |
+| `test/domain-utils.test.ts` | Repoint `resolveHover` / `resolveHyperlinkHandling` imports to `../src/interactivity` (test bodies stay) |
+| `test/interactivity-policy.test.ts` | New — resolver unit tests |
+| `test/interactivity-tooltips-suppress.test.ts` | New — tooltip suppression test |
+| `sample-for-templates/.../_Measures.tmdl` | Mark modal overlay `data-hc-suppress='all'` — **untracked UAT scratch, edited locally, not committed** |
+
+> **Deliberately left alone.** `shouldDimPoint` stays in `domain-utils.ts` (a render-time selection predicate used 4× there; moving it only creates a back-import). The rest of `domain-utils.ts` (styling/templating/reconcile) is a separate, larger cleanup — out of scope. Test files are repointed, not physically relocated, to avoid churning shared describe/setup blocks.
+
+> **Author-facing documentation is out of scope for this plan.** The v2 author guide lives in the untracked `docs/v2/` working set and is maintained separately by the maintainer — do not edit or reference it from code or commits.
+
+> **The sample report is untracked UAT scratch.** `sample-for-templates/` is a local working asset (too data-heavy to be a permanent corpus) and will stay untracked. Task 7 edits it locally to exercise the feature, but **does not commit it** — do not `git add` anything under `sample-for-templates/`. A lighter, committable UAT corpus for this feature is a separate follow-up.
+
+---
+
+# Phase A — Consolidate the interactivity surface (behavior-preserving)
+
+## Task 1: Move `behavior.ts` into `src/interactivity/`
+
+**Files:**
+- Move: `src/behavior.ts` → `src/interactivity/behavior.ts`
+- Create: `src/interactivity/index.ts`
+- Modify: `src/visual.ts` (import on line 42), `test/behavior.test.ts` (import on line 2)
+
+- [ ] **Step 1: Move the file with git**
+
+```bash
+mkdir -p src/interactivity
+git mv src/behavior.ts src/interactivity/behavior.ts
+```
+
+- [ ] **Step 2: Fix the moved file's relative imports**
+
+In `src/interactivity/behavior.ts`, the imports now sit one directory deeper. Update these five import paths (add `../`):
+
+```ts
+import { IHtmlEntry, IViewModel } from '../view-model';
+import { VisualConstants } from '../visual-constants';
+import { shouldDimPoint } from '../domain-utils';
+import { recordEvent } from '../diagnostics/event-recorder';
+import { tooltipContext, TooltipItem } from '../diagnostics/host-events';
+```
+
+(The `powerbi-visuals-utils-interactivityutils` import at the top is a package import — leave it unchanged.)
+
+- [ ] **Step 3: Create the barrel**
+
+Create `src/interactivity/index.ts`:
+
+```ts
+// Public interactivity surface. Consumers import from './interactivity'
+// rather than reaching into individual modules.
+export { BehaviorManager, IHtmlBehaviorOptions } from './behavior';
+```
+
+- [ ] **Step 4: Repoint `visual.ts`**
+
+In `src/visual.ts`, replace the behavior import on line 42:
+
+```ts
+import { BehaviorManager, IHtmlBehaviorOptions } from './behavior';
+```
+
+with:
+
+```ts
+import { BehaviorManager, IHtmlBehaviorOptions } from './interactivity';
+```
+
+- [ ] **Step 5: Repoint the test**
+
+In `test/behavior.test.ts`, change line 2:
+
+```ts
+import { BehaviorManager } from '../src/behavior';
+```
+
+to:
+
+```ts
+import { BehaviorManager } from '../src/interactivity';
+```
+
+- [ ] **Step 6: Run the suite — must stay green**
+
+Run: `npx vitest run`
+Expected: PASS (no behaviour changed; only paths moved).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A src/interactivity src/visual.ts test/behavior.test.ts
+git commit -m "refactor(interactivity): move BehaviorManager into src/interactivity
+
+Pure relocation + barrel. No behaviour change.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Extract tooltips into `src/interactivity/tooltips.ts`
+
+**Files:**
+- Create: `src/interactivity/tooltips.ts`
+- Modify: `src/domain-utils.ts` (remove `resolveHover` + the two binders, lines ~532–657, and the now-unused imports on lines 31–32), `src/interactivity/index.ts`, `src/visual.ts`, `test/domain-utils.test.ts`
+
+- [ ] **Step 1: Create the new module with its import header**
+
+Create `src/interactivity/tooltips.ts` with this header, then (Step 2) paste the moved bodies beneath it:
+
+```ts
+// Power BI API Dependencies
+import powerbi from 'powerbi-visuals-api';
+import IVisualHost = powerbi.extensibility.visual.IVisualHost;
+import TooltipShowOptions = powerbi.extensibility.TooltipShowOptions;
+import VisualTooltipDataItem = powerbi.extensibility.VisualTooltipDataItem;
+
+// External dependencies
+import { select, Selection } from 'd3-selection';
+
+// Internal dependencies
+import { VisualConstants } from '../visual-constants';
+import { IHtmlEntry } from '../view-model';
+import { recordTooltipEvent } from '../diagnostics/event-recorder';
+import { tooltipContext, TooltipItem } from '../diagnostics/host-events';
+```
+
+- [ ] **Step 2: Move the three functions verbatim**
+
+Cut these three functions **verbatim** from `src/domain-utils.ts` (the contiguous block at lines ~532–657 — the `resolveHover` JSDoc + `export function resolveHover`, then `bindManualTooltips`, then `bindStandardTooltips`) and paste them into `src/interactivity/tooltips.ts` below the header. `resolveHover` keeps its `export`; the two `bind*` helpers stay module-private (no `export`). Do not change their bodies in this task.
+
+- [ ] **Step 3: Remove the now-orphaned imports from `domain-utils.ts`**
+
+The tooltip functions were the only users of these. Delete lines 31–32:
+
+```ts
+import { recordTooltipEvent } from './diagnostics/event-recorder';
+import { tooltipContext, TooltipItem } from './diagnostics/host-events';
+```
+
+…and the two tooltip type imports on lines 5–6, which are also now unused (they
+appeared only in the moved binders):
+
+```ts
+import TooltipShowOptions = powerbi.extensibility.TooltipShowOptions;
+import VisualTooltipDataItem = powerbi.extensibility.VisualTooltipDataItem;
+```
+
+Verify nothing else references any of them:
+
+Run: `grep -n "recordTooltipEvent\|tooltipContext\|TooltipItem\|TooltipShowOptions\|VisualTooltipDataItem" src/domain-utils.ts`
+Expected: no matches.
+
+> Note: **do not** remove `IVisualHost` (line 3) yet — `resolveHyperlinkHandling`
+> still uses it until Task 3. Also leave `import { select, Selection } from
+> 'd3-selection';` — other functions there still use `select` (e.g. lines
+> 964/1011/1047).
+
+- [ ] **Step 4: Add to the barrel**
+
+In `src/interactivity/index.ts`, add:
+
+```ts
+export { resolveHover } from './tooltips';
+```
+
+- [ ] **Step 5: Repoint `visual.ts`**
+
+In `src/visual.ts`, remove `resolveHover` from the `from './domain-utils'` import group (lines 27–40) and add it to the interactivity import (the line edited in Task 1), which becomes:
+
+```ts
+import {
+    BehaviorManager,
+    IHtmlBehaviorOptions,
+    resolveHover
+} from './interactivity';
+```
+
+- [ ] **Step 6: Repoint the tooltip tests**
+
+In `test/domain-utils.test.ts`, the `resolveHover` symbol is imported in the `from '../src/domain-utils'` group (around lines 1–18, `resolveHover` is on line 17). Remove `resolveHover` from that group and add a new import near the top of the file:
+
+```ts
+import { resolveHover } from '../src/interactivity';
+```
+
+(Leave the `resolveHover(...)` test bodies — around lines 1841–1900 — exactly where they are.)
+
+- [ ] **Step 7: Run the suite — must stay green**
+
+Run: `npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A src/interactivity src/domain-utils.ts src/visual.ts test/domain-utils.test.ts
+git commit -m "refactor(interactivity): extract resolveHover/tooltips from domain-utils
+
+Move the hover + standard/manual tooltip binders into
+src/interactivity/tooltips.ts and drop the now-unused diagnostics
+imports from domain-utils. No behaviour change.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Extract hyperlinks into `src/interactivity/hyperlinks.ts`
+
+**Files:**
+- Create: `src/interactivity/hyperlinks.ts`
+- Modify: `src/domain-utils.ts` (remove `resolveHyperlinkHandling`, lines ~440–480), `src/interactivity/index.ts`, `src/visual.ts`, `test/domain-utils.test.ts`
+
+- [ ] **Step 1: Create the new module with its import header**
+
+Create `src/interactivity/hyperlinks.ts` with this header, then (Step 2) paste the moved body beneath it:
+
+```ts
+// Power BI API Dependencies
+import powerbi from 'powerbi-visuals-api';
+import IVisualHost = powerbi.extensibility.visual.IVisualHost;
+
+// External dependencies
+import { select, Selection } from 'd3-selection';
+```
+
+- [ ] **Step 2: Move the function verbatim**
+
+Cut `resolveHyperlinkHandling` **verbatim** from `src/domain-utils.ts` (the JSDoc, if any, + `export function resolveHyperlinkHandling` through its closing brace — lines ~440–480) and paste it into `src/interactivity/hyperlinks.ts` below the header. Keep its `export`. Do not change the body.
+
+- [ ] **Step 3: Remove the now-orphaned `IVisualHost` import from `domain-utils.ts`**
+
+`resolveHyperlinkHandling` was the last user of `IVisualHost` (the tooltip
+functions that also used it left in Task 2). Delete line 3:
+
+```ts
+import IVisualHost = powerbi.extensibility.visual.IVisualHost;
+```
+
+`select` and `Selection` stay — other functions still use them. Verify both the
+symbol and the orphaned import are gone:
+
+Run: `grep -n "resolveHyperlinkHandling\|IVisualHost" src/domain-utils.ts`
+Expected: no matches.
+
+- [ ] **Step 4: Add to the barrel**
+
+In `src/interactivity/index.ts`, add:
+
+```ts
+export { resolveHyperlinkHandling } from './hyperlinks';
+```
+
+- [ ] **Step 5: Repoint `visual.ts`**
+
+In `src/visual.ts`, remove `resolveHyperlinkHandling` from the `from './domain-utils'` import group and add it to the interactivity import, which becomes:
+
+```ts
+import {
+    BehaviorManager,
+    IHtmlBehaviorOptions,
+    resolveHover,
+    resolveHyperlinkHandling
+} from './interactivity';
+```
+
+- [ ] **Step 6: Repoint the hyperlink tests**
+
+In `test/domain-utils.test.ts`, remove `resolveHyperlinkHandling` from the `from '../src/domain-utils'` import group (line 8) and add it to the interactivity import added in Task 2:
+
+```ts
+import { resolveHover, resolveHyperlinkHandling } from '../src/interactivity';
+```
+
+(Leave the `resolveHyperlinkHandling` test body — the `describe` at line ~930 — where it is.)
+
+- [ ] **Step 7: Run the suite — must stay green**
+
+Run: `npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A src/interactivity src/domain-utils.ts src/visual.ts test/domain-utils.test.ts
+git commit -m "refactor(interactivity): extract resolveHyperlinkHandling from domain-utils
+
+Move link-click delegation into src/interactivity/hyperlinks.ts.
+The interactivity surface is now consolidated. No behaviour change.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase B — Add `data-hc-suppress` on the clean surface
+
+## Task 4: Resolver module + constants
+
+**Files:**
+- Modify: `src/visual-constants.ts` (the `dom: { ... }` block, ends ~line 264)
+- Create: `src/interactivity/policy.ts`
+- Modify: `src/interactivity/index.ts`
+- Test: `test/interactivity-policy.test.ts`
+
+- [ ] **Step 1: Add the constants**
+
+In `src/visual-constants.ts`, inside the `dom: {` object, add a comma after the `contentSlotMarker: 'HC:CONTENT'` line and append:
+
+```ts
+        contentSlotMarker: 'HC:CONTENT',
+        // Declarative interactivity suppression. An author adds
+        // data-hc-suppress="filter context-menu tooltip" (or "all") to a node to
+        // make it + its descendants inert to the visual's cross-filter / context
+        // menu / tooltip handling, deferring to their own / native behaviour.
+        // Works in every edition because the visual reads the markup itself.
+        suppressAttr: 'data-hc-suppress',
+        suppressAllToken: 'all'
+```
+
+- [ ] **Step 2: Write the failing unit test**
+
+Create `test/interactivity-policy.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveInteractivity } from '../src/interactivity';
+
+// Build <root><mid [attr]><leaf></leaf></mid></root> and return leaf.
+function tree(attr?: string): Element {
+    const root = document.createElement('div');
+    const mid = document.createElement('div');
+    if (attr !== undefined) mid.setAttribute('data-hc-suppress', attr);
+    const leaf = document.createElement('span');
+    mid.appendChild(leaf);
+    root.appendChild(mid);
+    return leaf;
+}
+
+describe('resolveInteractivity', () => {
+    it('allows everything when no ancestor suppresses', () => {
+        const leaf = tree();
+        expect(resolveInteractivity(leaf, 'filter')).toBe(true);
+        expect(resolveInteractivity(leaf, 'tooltip')).toBe(true);
+        expect(resolveInteractivity(leaf, 'context-menu')).toBe(true);
+    });
+
+    it('suppresses only the named token', () => {
+        const leaf = tree('filter');
+        expect(resolveInteractivity(leaf, 'filter')).toBe(false);
+        expect(resolveInteractivity(leaf, 'tooltip')).toBe(true);
+    });
+
+    it('"all" suppresses every token', () => {
+        const leaf = tree('all');
+        expect(resolveInteractivity(leaf, 'filter')).toBe(false);
+        expect(resolveInteractivity(leaf, 'tooltip')).toBe(false);
+        expect(resolveInteractivity(leaf, 'context-menu')).toBe(false);
+    });
+
+    it('reads multiple space-separated tokens', () => {
+        const leaf = tree('filter tooltip');
+        expect(resolveInteractivity(leaf, 'filter')).toBe(false);
+        expect(resolveInteractivity(leaf, 'tooltip')).toBe(false);
+        expect(resolveInteractivity(leaf, 'context-menu')).toBe(true);
+    });
+
+    it('inherits suppression from an ancestor (descendants included)', () => {
+        const leaf = tree('all'); // attr on mid, query the leaf below it
+        expect(resolveInteractivity(leaf, 'filter')).toBe(false);
+    });
+
+    it('ignores unknown tokens', () => {
+        const leaf = tree('foo bar');
+        expect(resolveInteractivity(leaf, 'filter')).toBe(true);
+    });
+
+    it('treats a null node as allowed', () => {
+        expect(resolveInteractivity(null, 'filter')).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run test/interactivity-policy.test.ts`
+Expected: FAIL — `resolveInteractivity` is not exported from `../src/interactivity`.
+
+- [ ] **Step 4: Implement the resolver**
+
+Create `src/interactivity/policy.ts`:
+
+```ts
+import { VisualConstants } from '../visual-constants';
+
+/** Interaction categories an author can suppress via `data-hc-suppress`. */
+export type InteractionToken = 'filter' | 'context-menu' | 'tooltip';
+
+/**
+ * Whether a given interaction is allowed for `node`. Walks from `node` up the
+ * parent chain; if any ancestor's `data-hc-suppress` attribute names `token`
+ * (or the `all` wildcard), the interaction is suppressed.
+ *
+ * No boundary is tracked — `data-hc-suppress` only ever appears inside author
+ * content, so walking to the document root is safe.
+ *
+ * @param node  - the event target (or any element to test)
+ * @param token - the interaction category
+ * @returns true when allowed (default), false when suppressed
+ */
+export function resolveInteractivity(
+    node: Element | null,
+    token: InteractionToken
+): boolean {
+    const { suppressAttr, suppressAllToken } = VisualConstants.dom;
+    let el: Element | null = node;
+    while (el) {
+        const raw = el.getAttribute(suppressAttr);
+        if (raw) {
+            // ponytail: linear parent-chain walk, called per click and per
+            // mousemove. Fine at normal DOM depth; memoise only if a profiler on
+            // multi-MB content complains.
+            const tokens = raw.split(/\s+/);
+            if (tokens.includes(token) || tokens.includes(suppressAllToken)) {
+                return false;
+            }
+        }
+        el = el.parentElement;
+    }
+    return true;
+}
+```
+
+- [ ] **Step 5: Export from the barrel**
+
+In `src/interactivity/index.ts`, add:
+
+```ts
+export { resolveInteractivity } from './policy';
+```
+
+(`InteractionToken` stays defined in `policy.ts` as its own param type — no
+consumer imports it, so it is not re-exported from the barrel.)
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx vitest run test/interactivity-policy.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/visual-constants.ts src/interactivity/policy.ts src/interactivity/index.ts test/interactivity-policy.test.ts
+git commit -m "feat(interactivity): add data-hc-suppress resolver
+
+resolveInteractivity walks the parent chain for a data-hc-suppress
+attribute naming filter / context-menu / tooltip (or all). Pure, no
+wiring yet.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wire suppression into behavior (cross-filter + context menu)
+
+**Files:**
+- Modify: `src/interactivity/behavior.ts` (`handleSelectionClick`, `handleContextMenu`, `bindClearCatcher`)
+- Test: `test/behavior.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/behavior.test.ts`, add this `describe` block at the end of the file:
+
+```ts
+describe('interactivity suppression in behavior', () => {
+    it('suppresses cross-filter when the target is under data-hc-suppress=filter', () => {
+        const mgr = new BehaviorManager<any>();
+        const { options } = makeOptions(vi.fn());
+        const handler = { handleSelection: vi.fn(), handleContextMenu: vi.fn(), handleClearSelection: vi.fn() };
+        mgr.bindEvents(options as any, handler as any);
+
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'filter');
+        const inner = document.createElement('button');
+        modal.appendChild(inner);
+
+        const evt = { preventDefault: vi.fn(), stopPropagation: vi.fn(), ctrlKey: false, target: inner } as any;
+        mgr.handleSelectionClick(evt, { tooltips: [] } as any);
+
+        expect(evt.stopPropagation).toHaveBeenCalled(); // don't fall through to clear-catcher
+        expect(handler.handleSelection).not.toHaveBeenCalled();
+    });
+
+    it('still cross-filters when the target is outside any suppressed subtree', () => {
+        const mgr = new BehaviorManager<any>();
+        const { options } = makeOptions(vi.fn());
+        const handler = { handleSelection: vi.fn(), handleContextMenu: vi.fn(), handleClearSelection: vi.fn() };
+        mgr.bindEvents(options as any, handler as any);
+
+        const inner = document.createElement('button'); // no suppressing ancestor
+        const evt = { preventDefault: vi.fn(), stopPropagation: vi.fn(), ctrlKey: false, target: inner } as any;
+        mgr.handleSelectionClick(evt, { tooltips: [] } as any);
+
+        expect(handler.handleSelection).toHaveBeenCalled();
+    });
+
+    it('shows no context menu (but preventDefaults) under data-hc-suppress=all', () => {
+        const mgr = new BehaviorManager<any>();
+        const { options } = makeOptions(vi.fn());
+        const handler = { handleSelection: vi.fn(), handleContextMenu: vi.fn(), handleClearSelection: vi.fn() };
+        mgr.bindEvents(options as any, handler as any);
+
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'all');
+        const inner = document.createElement('span');
+        modal.appendChild(inner);
+
+        const evt = { preventDefault: vi.fn(), stopPropagation: vi.fn(), clientX: 1, clientY: 2, target: inner } as any;
+        mgr.handleContextMenu(evt, { tooltips: [] } as any);
+
+        expect(evt.preventDefault).toHaveBeenCalled(); // swallow the native browser menu too
+        expect(handler.handleContextMenu).not.toHaveBeenCalled();
+    });
+
+    it('skips the clear-catcher clear when the target is under data-hc-suppress=filter', () => {
+        const mgr = new BehaviorManager<any>();
+        const { options, clear } = makeOptions(vi.fn());
+        const handler = { handleSelection: vi.fn(), handleContextMenu: vi.fn(), handleClearSelection: vi.fn() };
+        mgr.bindEvents(options as any, handler as any);
+
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'filter');
+        const inner = document.createElement('div');
+        modal.appendChild(inner);
+
+        const clickCall = (clear.on as any).mock.calls.find((c: any[]) => c[0] === 'click');
+        clickCall[1]({ preventDefault: vi.fn(), stopPropagation: vi.fn(), target: inner });
+
+        expect(handler.handleClearSelection).not.toHaveBeenCalled();
+    });
+});
+```
+
+> Note: the existing `makeOptions` helper builds `viewModel: { hasCrossFiltering: true }`, so the clear-catcher click handler runs. The existing instrumentation tests pass mock events without `target`, so `resolveInteractivity(undefined, …)` returns `true` and their behaviour is unchanged.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run test/behavior.test.ts -t "interactivity suppression in behavior"`
+Expected: FAIL — `handleSelection` / `handleClearSelection` still called.
+
+- [ ] **Step 3: Add the import**
+
+At the top of `src/interactivity/behavior.ts`, after the `import { tooltipContext, TooltipItem } from '../diagnostics/host-events';` line, add:
+
+```ts
+import { resolveInteractivity } from './policy';
+```
+
+- [ ] **Step 4: Guard `handleSelectionClick`**
+
+In `src/interactivity/behavior.ts`, replace the `handleSelectionClick` method body so the suppression guard runs first:
+
+```ts
+    handleSelectionClick(event: MouseEvent, d: IHtmlEntry) {
+        if (!resolveInteractivity(event.target as Element | null, 'filter')) {
+            // Inert region: don't toggle, and stop the click reaching the
+            // clear-catcher (which would otherwise wipe the selection).
+            event.stopPropagation();
+            return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        this.options.hideTooltip();
+        // `d.selected` is the PRE-toggle state, so a Ctrl+click on an already-
+        // selected point removes it from the selection, otherwise it adds it; a
+        // plain click replaces the selection. Surfacing add/remove makes it
+        // clear how each click changes the multi-select context.
+        const op = event.ctrlKey ? (d.selected ? 'remove' : 'add') : 'select';
+        recordEvent('cross-filter', op, this.pointContext(d) || undefined);
+        this.selectionHandler.handleSelection(d, event.ctrlKey);
+    }
+```
+
+- [ ] **Step 5: Guard `handleContextMenu`**
+
+In `src/interactivity/behavior.ts`, replace the `handleContextMenu` method body so it always `preventDefault`s but shows nothing when suppressed:
+
+```ts
+    handleContextMenu(event: MouseEvent, d: IHtmlEntry | null) {
+        // Always preventDefault so the browser's native menu never appears.
+        event.preventDefault();
+        if (!resolveInteractivity(event.target as Element | null, 'context-menu')) {
+            // Inert region: show neither our drill menu nor the native one.
+            return;
+        }
+        event.stopPropagation();
+        this.options.hideTooltip();
+        recordEvent(
+            'drill',
+            `context-menu @ (${event.clientX},${event.clientY})`,
+            d ? this.pointContext(d) || undefined : 'background'
+        );
+        event &&
+            this.selectionHandler.handleContextMenu(d, {
+                x: event.clientX,
+                y: event.clientY
+            });
+    }
+```
+
+- [ ] **Step 6: Guard the clear-catcher click**
+
+In `src/interactivity/behavior.ts`, in `bindClearCatcher`, add the suppression check as the first statement inside the `if (hasCrossFiltering) {` block:
+
+```ts
+        clearCatcherSelection.on('click', (event) => {
+            if (hasCrossFiltering) {
+                if (!resolveInteractivity(event.target as Element | null, 'filter')) {
+                    return; // inert region — don't clear
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                this.options.hideTooltip();
+                recordEvent('cross-filter', 'cleared');
+                const mouseEvent: MouseEvent = <MouseEvent>event;
+                mouseEvent && this.selectionHandler.handleClearSelection();
+            }
+        });
+```
+
+- [ ] **Step 7: Run the behavior tests to verify they pass**
+
+Run: `npx vitest run test/behavior.test.ts`
+Expected: PASS (all existing + 4 new).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/interactivity/behavior.ts test/behavior.test.ts
+git commit -m "feat(interactivity): honour data-hc-suppress for click and context menu
+
+Cross-filter clicks under a suppressed subtree stopPropagation without
+toggling (so they don't reach the clear-catcher); the clear-catcher
+skips clearing for suppressed targets; context-menu suppression
+preventDefaults and shows no menu at all.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Wire suppression into tooltips
+
+**Files:**
+- Modify: `src/interactivity/tooltips.ts` (`bindManualTooltips`, `bindStandardTooltips`)
+- Test: `test/interactivity-tooltips-suppress.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/interactivity-tooltips-suppress.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { resolveHover } from '../src/interactivity';
+
+function makeHost() {
+    return { tooltipService: { show: vi.fn(), hide: vi.fn() } } as any;
+}
+
+// Mock d3 selection that captures bound handlers and stubs selectAll.
+function makeDataElements() {
+    const handlers: Record<string, (e: any, d: any) => void> = {};
+    const manual = { on: vi.fn().mockReturnThis() };
+    const sel: any = {
+        on: vi.fn((evt: string, cb: any) => {
+            handlers[evt] = cb;
+            return sel;
+        }),
+        selectAll: vi.fn(() => manual)
+    };
+    return { sel, handlers };
+}
+
+describe('contextual tooltip suppression', () => {
+    it('hides instead of showing over a data-hc-suppress=tooltip subtree', () => {
+        const { sel, handlers } = makeDataElements();
+        const host = makeHost();
+        resolveHover(sel, host, false);
+
+        const row = document.createElement('div');
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'tooltip');
+        const inner = document.createElement('span');
+        modal.appendChild(inner);
+        row.appendChild(modal);
+
+        handlers['mouseover mousemove'](
+            { target: inner, currentTarget: row, clientX: 0, clientY: 0 },
+            { tooltips: [{ displayName: 'x', value: 'y' }], identity: {} }
+        );
+
+        expect(host.tooltipService.hide).toHaveBeenCalled();
+        expect(host.tooltipService.show).not.toHaveBeenCalled();
+    });
+
+    it('still shows the tooltip outside any suppressed subtree', () => {
+        const { sel, handlers } = makeDataElements();
+        const host = makeHost();
+        resolveHover(sel, host, false);
+
+        const row = document.createElement('div');
+        const inner = document.createElement('span');
+        row.appendChild(inner);
+
+        handlers['mouseover mousemove'](
+            { target: inner, currentTarget: row, clientX: 0, clientY: 0 },
+            { tooltips: [{ displayName: 'x', value: 'y' }], identity: {} }
+        );
+
+        expect(host.tooltipService.show).toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run test/interactivity-tooltips-suppress.test.ts`
+Expected: FAIL — `show` is called in the first test (suppression not yet wired).
+
+- [ ] **Step 3: Add the import**
+
+At the top of `src/interactivity/tooltips.ts`, after the existing internal imports, add:
+
+```ts
+import { resolveInteractivity } from './policy';
+```
+
+- [ ] **Step 4: Guard `bindStandardTooltips`**
+
+In `src/interactivity/tooltips.ts`, replace the `dataElements.on('mouseover mousemove', …)` handler in `bindStandardTooltips` so it bails out (hiding) over a suppressed target:
+
+```ts
+    dataElements.on('mouseover mousemove', (event, d) => {
+        if (!resolveInteractivity(event.target as Element | null, 'tooltip')) {
+            tooltipService.hide({ immediately: true, isTouchEvent: true });
+            return;
+        }
+        select(event.currentTarget).classed(
+            VisualConstants.dom.hoverClassSelector,
+            true
+        );
+        if (hasGranularity || d.tooltips.length > 0) {
+            const options: TooltipShowOptions = {
+                coordinates: [event.clientX, event.clientY],
+                isTouchEvent: true,
+                dataItems: d.tooltips,
+                identities: [d.identity]
+            };
+            tooltipService.show(options);
+            recordTooltipEvent(
+                'show',
+                'contextual',
+                tooltipContext(d.tooltips as TooltipItem[])
+            );
+        }
+    });
+```
+
+- [ ] **Step 5: Guard `bindManualTooltips`**
+
+In `src/interactivity/tooltips.ts`, in `bindManualTooltips`, add the same guard as the first statement inside the `manualTooltipElements.on('mouseover mousemove', (event) => {` handler:
+
+```ts
+    manualTooltipElements.on('mouseover mousemove', (event) => {
+        if (!resolveInteractivity(event.target as Element | null, 'tooltip')) {
+            tooltipService.hide({ immediately: true, isTouchEvent: true });
+            return;
+        }
+        const dataset = event.currentTarget.dataset;
+```
+
+(Leave the rest of the handler unchanged.)
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx vitest run test/interactivity-tooltips-suppress.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npx vitest run`
+Expected: PASS (no regressions).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/interactivity/tooltips.ts test/interactivity-tooltips-suppress.test.ts
+git commit -m "feat(interactivity): honour data-hc-suppress for tooltips
+
+Standard and manual tooltip handlers hide and bail out when the hovered
+target sits under a data-hc-suppress=tooltip (or all) subtree.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Mark the sample modal overlay (local UAT only — not committed)
+
+**Files:**
+- Modify **locally, do not commit**: `sample-for-templates/SampleReportML.SemanticModel/definition/tables/_Measures.tmdl` (lines 420 and 590 — the two `_modalHtml` definitions in `Team Card Body Template` and `Team Card Content`)
+
+`sample-for-templates/` is untracked UAT scratch and stays that way. This task edits it only to exercise the feature in Power BI Desktop; there is no commit and no `git add`. No automated test — verified by manual UAT (clicking the modal must not cross-filter or show the card tooltip).
+
+- [ ] **Step 1: Add the marker in `Team Card Body Template` (line 420)**
+
+Find this exact substring on line 420:
+
+```
+<div id='modal_" & _empId & "' class='modal-overlay'>
+```
+
+Replace it with:
+
+```
+<div id='modal_" & _empId & "' class='modal-overlay' data-hc-suppress='all'>
+```
+
+- [ ] **Step 2: Add the marker in `Team Card Content` (line 590)**
+
+Line 590 contains the identical substring. Apply the identical replacement there. Do not alter the adjacent `more-link` / `modal-close` spans.
+
+- [ ] **Step 3: Verify both lines changed**
+
+Run: `grep -n "data-hc-suppress='all'" sample-for-templates/SampleReportML.SemanticModel/definition/tables/_Measures.tmdl`
+Expected: two matches (lines ~420 and ~590), each on a `modal-overlay` div.
+
+- [ ] **Step 4: Do NOT commit**
+
+Leave the edit in the working tree for UAT. `sample-for-templates/` is untracked and stays untracked — do not `git add` it. Confirm it is not staged:
+
+Run: `git status --short sample-for-templates/`
+Expected: shows the files as untracked (`??`) only — nothing staged.
+
+---
+
+## Final verification
+
+- [ ] **Run the full test suite** — `npx vitest run` → all pass.
+- [ ] **Type-check / build** — run the project's build (e.g. the configured `pbiviz` build) and confirm no TypeScript errors from the moved/added imports.
+- [ ] **Confirm the surface** — `src/interactivity/` contains `index.ts`, `behavior.ts`, `tooltips.ts`, `hyperlinks.ts`, `policy.ts`; `grep -rn "from './behavior'\|resolveHover\|resolveHyperlinkHandling" src/domain-utils.ts` returns nothing.
+- [ ] **Manual UAT (sample report)** — open the Team Cards sample in Power BI Desktop with cross-filtering on: clicking inside an open modal must **not** select/deselect the card or clear the selection; hovering the modal must **not** show the employee tooltip; the modal's ✕ close still works; clicking the card itself still cross-filters.
+
+---
+
+## Notes for the implementer
+
+- **Phase A is behavior-preserving:** every move keeps the suite green. If a move turns a test red, the import path or a relative path inside the moved file is wrong — fix the path, don't change logic.
+- **Why the existing behavior tests still pass after wiring:** they invoke handlers with mock events that have no `target`. `resolveInteractivity(undefined, …)` walks zero nodes and returns `true`, so unsuppressed behaviour is unchanged.
+- **No new event bindings in Phase B:** every change is an early-out inside a handler that already exists. Don't add listeners.
+- **`event.target` vs `event.currentTarget`:** always pass `event.target` (the actual element under the pointer/click) to `resolveInteractivity`, not `currentTarget` (the row root the handler is delegated on).
+- **Out of scope (do not build):** `data-hc-force` re-enabling, restructuring modals out of the row, per-token hyperlink suppression, moving `shouldDimPoint`, and any further `domain-utils.ts` de-grab-bagging. See the spec's Out-of-scope section.
+```

--- a/src/domain-utils.ts
+++ b/src/domain-utils.ts
@@ -1,6 +1,5 @@
 // Power BI API Dependencies
 import powerbi from 'powerbi-visuals-api';
-import IVisualHost = powerbi.extensibility.visual.IVisualHost;
 import ISelectionId = powerbi.visuals.ISelectionId;
 
 // External dependencies
@@ -424,56 +423,6 @@ export const getDiagnosticsRawHtml = (
     }
     return getRawHtml(styleSheetContainer, contentContainer, stylesheet);
 };
-
-/**
- * For the specified element, process all hyperlinks so that they are either explicitly denied,
- * or delegated to the Power BI visual host for permission to open.
- *
- * @param host              - The Power BI visual host services object.
- * @param container         - The container to process.
- * @param allowDelegation   - Allow hyperlinks to be delegated to Power BI.
- */
-export function resolveHyperlinkHandling(
-    host: IVisualHost,
-    container: Selection<any, any, any, any>,
-    allowDelegation?: boolean
-) {
-    container.selectAll('a').on('click', (event) => {
-        // preventDefault unconditionally - when delegation is off, the
-        // click must be a no-op (no navigation, no host.launchUrl call).
-        event.preventDefault();
-        if (!allowDelegation) return;
-        // `select(...).attr('href')` reads only the unprefixed form,
-        // so fall back to `xlink:href` for SVG 1.1 authored anchors.
-        // In the normal sanitized path this fallback never matches:
-        // `<a>` takes the HTML branch in the sanitizer and
-        // `xlink:href` is not in `ALLOWED_ATTRIBUTES['a']`, so it is
-        // dropped by the per-tag allowlist before the URL scheme check
-        // runs (see fixture `hyperlinks-reject-svg-xlink-href-legacy`).
-        // Retained as defense-in-depth for any unsanitized content
-        // that reaches this handler, and exercised by the bypass test.
-        const sel = select(event.currentTarget as Element);
-        const url = (sel.attr('href') || sel.attr('xlink:href') || '').trim();
-        // Defense-in-depth: even though the sanitizer already restricts
-        // <a href> / <a xlink:href> to http/https, re-check at the call
-        // boundary before handing the URL to host.launchUrl(). Power BI's
-        // launchUrl contract requires http(s); any other scheme reaching
-        // here is a sanitizer bypass and must be rejected — silently, so
-        // the user sees no action and no error.
-        if (!/^https?:\/\//i.test(url)) return;
-        // Fail-soft envelope around the host boundary. host.launchUrl is
-        // owned by Power BI and may throw in embedded / restricted-host
-        // scenarios; an uncaught throw would propagate through d3's
-        // event dispatch and break later click handlers. Log and
-        // swallow — the user sees no action and no error, consistent
-        // with the silent-reject posture for non-http(s) URLs above.
-        try {
-            host.launchUrl(url);
-        } catch (err) {
-            console.warn('host.launchUrl failed:', err);
-        }
-    });
-}
 
 /**
  * As we want to display different types of element for each entry/grouping, we will clear down the

--- a/src/domain-utils.ts
+++ b/src/domain-utils.ts
@@ -2,8 +2,6 @@
 import powerbi from 'powerbi-visuals-api';
 import IVisualHost = powerbi.extensibility.visual.IVisualHost;
 import ISelectionId = powerbi.visuals.ISelectionId;
-import TooltipShowOptions = powerbi.extensibility.TooltipShowOptions;
-import VisualTooltipDataItem = powerbi.extensibility.VisualTooltipDataItem;
 
 // External dependencies
 import { select, Selection } from 'd3-selection';
@@ -28,8 +26,6 @@ import {
 } from './sanitize';
 import { CONTENT_TOKEN, ROW_TOKEN, substitute } from './template-engine';
 import { buildHighlightedFragment } from './diagnostics/highlight-html';
-import { recordTooltipEvent } from './diagnostics/event-recorder';
-import { tooltipContext, TooltipItem } from './diagnostics/host-events';
 
 // Re-export sanitize pipeline entry points so existing callers that import
 // from './domain-utils' continue to work after the Task 7 extraction.
@@ -526,133 +522,6 @@ export function resolveScrollableContent(
         scrollbars: {
             clickScrolling: true
         }
-    });
-}
-
-/**
- * Handle eventing when a data element is hovred over. This includes showing
- * the tooltip and toggling appropriate class names for style hooks.
- *
- * @param dataElements      - The elements to analyse and process.
- * @param host              - Visual host services.
- * @param hasGranularity    - Whether we have granularity or not.
- */
-export function resolveHover(
-    dataElements: Selection<any, IHtmlEntry, any, any>,
-    host: IVisualHost,
-    hasGranularity: boolean
-) {
-    bindStandardTooltips(dataElements, host, hasGranularity);
-    bindManualTooltips(dataElements, host);
-}
-
-/**
- * If we don't have any granularity, we will look for elements that have
- * a tooltip attribute and use this to show the tooltip.
- *
- * @param dataElements      - The elements to analyse and process.
- * @param host              - Visual host services.
- */
-function bindManualTooltips(
-    dataElements: Selection<any, IHtmlEntry, any, any>,
-    host: IVisualHost
-) {
-    const { tooltipService } = host;
-    const {
-        manualTooltipSelector,
-        manualTooltipDataPrefix,
-        manualTooltipDataTitle,
-        manualTooltipDataValue
-    } = VisualConstants.dom;
-    const manualTooltipElements = dataElements.selectAll(
-        `.${manualTooltipSelector}`
-    );
-    const titleExp = new RegExp(
-        `${manualTooltipDataPrefix}${manualTooltipDataTitle}`,
-        'g'
-    );
-    const valueExp = new RegExp(
-        `${manualTooltipDataPrefix}${manualTooltipDataValue}`,
-        'g'
-    );
-    manualTooltipElements.on('mouseover mousemove', (event) => {
-        const dataset = event.currentTarget.dataset;
-        const keys = Object.keys(dataset).map((key) =>
-            key.replace(titleExp, '').replace(valueExp, '')
-        );
-        const uniqueKeys = [...new Set(keys)];
-        const dataItems: VisualTooltipDataItem[] = uniqueKeys.map((key) => ({
-            displayName:
-                dataset[
-                    `${manualTooltipDataPrefix}${manualTooltipDataTitle}${key}`
-                ] || '',
-            value:
-                dataset[
-                    `${manualTooltipDataPrefix}${manualTooltipDataValue}${key}`
-                ] || ''
-        }));
-        if (dataItems.length > 0) {
-            const options: TooltipShowOptions = {
-                coordinates: [event.clientX, event.clientY],
-                isTouchEvent: true,
-                dataItems,
-                identities: []
-            };
-            tooltipService.show(options);
-            recordTooltipEvent(
-                'show',
-                'manual',
-                tooltipContext(dataItems as TooltipItem[])
-            );
-        }
-    });
-    manualTooltipElements.on('mouseout', () => {
-        tooltipService.hide({ immediately: true, isTouchEvent: true });
-        recordTooltipEvent('hide', 'manual', '');
-    });
-}
-
-/**
- * For standard data elements, working with the data roles and correct
- * rules, we will apply the regular tooltip handling.
- *
- * @param dataElements      - The elements to analyse and process.
- * @param host              - Visual host services.
- * @param hasGranularity    - Whether we have granularity or not.
- */
-function bindStandardTooltips(
-    dataElements: Selection<any, IHtmlEntry, any, any>,
-    host: IVisualHost,
-    hasGranularity: boolean
-) {
-    const { tooltipService } = host;
-    dataElements.on('mouseover mousemove', (event, d) => {
-        select(event.currentTarget).classed(
-            VisualConstants.dom.hoverClassSelector,
-            true
-        );
-        if (hasGranularity || d.tooltips.length > 0) {
-            const options: TooltipShowOptions = {
-                coordinates: [event.clientX, event.clientY],
-                isTouchEvent: true,
-                dataItems: d.tooltips,
-                identities: [d.identity]
-            };
-            tooltipService.show(options);
-            recordTooltipEvent(
-                'show',
-                'contextual',
-                tooltipContext(d.tooltips as TooltipItem[])
-            );
-        }
-    });
-    dataElements.on('mouseout', (event) => {
-        select(event.currentTarget).classed(
-            VisualConstants.dom.hoverClassSelector,
-            false
-        );
-        tooltipService.hide({ immediately: true, isTouchEvent: true });
-        recordTooltipEvent('hide', 'contextual', '');
     });
 }
 

--- a/src/interactivity/behavior.ts
+++ b/src/interactivity/behavior.ts
@@ -9,6 +9,7 @@ import { VisualConstants } from '../visual-constants';
 import { shouldDimPoint } from '../domain-utils';
 import { recordEvent } from '../diagnostics/event-recorder';
 import { tooltipContext, TooltipItem } from '../diagnostics/host-events';
+import { resolveInteractivity } from './policy';
 
 /**
  * Behavior options for interactivity.
@@ -79,6 +80,12 @@ export class BehaviorManager<
      * @param d     - datum from selection
      */
     handleSelectionClick(event: MouseEvent, d: IHtmlEntry) {
+        if (!resolveInteractivity(event.target as Element | null, 'filter')) {
+            // Inert region: don't toggle, and stop the click reaching the
+            // clear-catcher (which would otherwise wipe the selection).
+            event.stopPropagation();
+            return;
+        }
         event.preventDefault();
         event.stopPropagation();
         this.options.hideTooltip();
@@ -98,7 +105,12 @@ export class BehaviorManager<
      * @param d     - datum from selection
      */
     handleContextMenu(event: MouseEvent, d: IHtmlEntry | null) {
+        // Always preventDefault so the browser's native menu never appears.
         event.preventDefault();
+        if (!resolveInteractivity(event.target as Element | null, 'context-menu')) {
+            // Inert region: show neither our drill menu nor the native one.
+            return;
+        }
         event.stopPropagation();
         this.options.hideTooltip();
         recordEvent(
@@ -123,6 +135,9 @@ export class BehaviorManager<
         } = this.options;
         clearCatcherSelection.on('click', (event) => {
             if (hasCrossFiltering) {
+                if (!resolveInteractivity(event.target as Element | null, 'filter')) {
+                    return; // inert region — don't clear
+                }
                 event.preventDefault();
                 event.stopPropagation();
                 this.options.hideTooltip();

--- a/src/interactivity/behavior.ts
+++ b/src/interactivity/behavior.ts
@@ -108,7 +108,9 @@ export class BehaviorManager<
         // Always preventDefault so the browser's native menu never appears.
         event.preventDefault();
         if (!resolveInteractivity(event.target as Element | null, 'context-menu')) {
-            // Inert region: show neither our drill menu nor the native one.
+            // Inert region: show neither our drill menu nor the native one, and
+            // stop the event bubbling to ancestor (clear-catcher / host) handlers.
+            event.stopPropagation();
             return;
         }
         event.stopPropagation();

--- a/src/interactivity/behavior.ts
+++ b/src/interactivity/behavior.ts
@@ -4,11 +4,11 @@ import BaseDataPoint = interactivityBaseService.BaseDataPoint;
 import IInteractiveBehavior = interactivityBaseService.IInteractiveBehavior;
 import ISelectionHandler = interactivityBaseService.ISelectionHandler;
 
-import { IHtmlEntry, IViewModel } from './view-model';
-import { VisualConstants } from './visual-constants';
-import { shouldDimPoint } from './domain-utils';
-import { recordEvent } from './diagnostics/event-recorder';
-import { tooltipContext, TooltipItem } from './diagnostics/host-events';
+import { IHtmlEntry, IViewModel } from '../view-model';
+import { VisualConstants } from '../visual-constants';
+import { shouldDimPoint } from '../domain-utils';
+import { recordEvent } from '../diagnostics/event-recorder';
+import { tooltipContext, TooltipItem } from '../diagnostics/host-events';
 
 /**
  * Behavior options for interactivity.

--- a/src/interactivity/hyperlinks.ts
+++ b/src/interactivity/hyperlinks.ts
@@ -1,0 +1,56 @@
+// Power BI API Dependencies
+import powerbi from 'powerbi-visuals-api';
+import IVisualHost = powerbi.extensibility.visual.IVisualHost;
+
+// External dependencies
+import { select, Selection } from 'd3-selection';
+
+/**
+ * For the specified element, process all hyperlinks so that they are either explicitly denied,
+ * or delegated to the Power BI visual host for permission to open.
+ *
+ * @param host              - The Power BI visual host services object.
+ * @param container         - The container to process.
+ * @param allowDelegation   - Allow hyperlinks to be delegated to Power BI.
+ */
+export function resolveHyperlinkHandling(
+    host: IVisualHost,
+    container: Selection<any, any, any, any>,
+    allowDelegation?: boolean
+) {
+    container.selectAll('a').on('click', (event) => {
+        // preventDefault unconditionally - when delegation is off, the
+        // click must be a no-op (no navigation, no host.launchUrl call).
+        event.preventDefault();
+        if (!allowDelegation) return;
+        // `select(...).attr('href')` reads only the unprefixed form,
+        // so fall back to `xlink:href` for SVG 1.1 authored anchors.
+        // In the normal sanitized path this fallback never matches:
+        // `<a>` takes the HTML branch in the sanitizer and
+        // `xlink:href` is not in `ALLOWED_ATTRIBUTES['a']`, so it is
+        // dropped by the per-tag allowlist before the URL scheme check
+        // runs (see fixture `hyperlinks-reject-svg-xlink-href-legacy`).
+        // Retained as defense-in-depth for any unsanitized content
+        // that reaches this handler, and exercised by the bypass test.
+        const sel = select(event.currentTarget as Element);
+        const url = (sel.attr('href') || sel.attr('xlink:href') || '').trim();
+        // Defense-in-depth: even though the sanitizer already restricts
+        // <a href> / <a xlink:href> to http/https, re-check at the call
+        // boundary before handing the URL to host.launchUrl(). Power BI's
+        // launchUrl contract requires http(s); any other scheme reaching
+        // here is a sanitizer bypass and must be rejected — silently, so
+        // the user sees no action and no error.
+        if (!/^https?:\/\//i.test(url)) return;
+        // Fail-soft envelope around the host boundary. host.launchUrl is
+        // owned by Power BI and may throw in embedded / restricted-host
+        // scenarios; an uncaught throw would propagate through d3's
+        // event dispatch and break later click handlers. Log and
+        // swallow — the user sees no action and no error, consistent
+        // with the silent-reject posture for non-http(s) URLs above.
+        try {
+            host.launchUrl(url);
+        } catch (err) {
+            console.warn('host.launchUrl failed:', err);
+        }
+    });
+}

--- a/src/interactivity/index.ts
+++ b/src/interactivity/index.ts
@@ -3,3 +3,4 @@
 export { BehaviorManager, IHtmlBehaviorOptions } from './behavior';
 export { resolveHover } from './tooltips';
 export { resolveHyperlinkHandling } from './hyperlinks';
+export { resolveInteractivity } from './policy';

--- a/src/interactivity/index.ts
+++ b/src/interactivity/index.ts
@@ -1,0 +1,3 @@
+// Public interactivity surface. Consumers import from './interactivity'
+// rather than reaching into individual modules.
+export { BehaviorManager, IHtmlBehaviorOptions } from './behavior';

--- a/src/interactivity/index.ts
+++ b/src/interactivity/index.ts
@@ -1,3 +1,4 @@
 // Public interactivity surface. Consumers import from './interactivity'
 // rather than reaching into individual modules.
 export { BehaviorManager, IHtmlBehaviorOptions } from './behavior';
+export { resolveHover } from './tooltips';

--- a/src/interactivity/index.ts
+++ b/src/interactivity/index.ts
@@ -2,3 +2,4 @@
 // rather than reaching into individual modules.
 export { BehaviorManager, IHtmlBehaviorOptions } from './behavior';
 export { resolveHover } from './tooltips';
+export { resolveHyperlinkHandling } from './hyperlinks';

--- a/src/interactivity/policy.ts
+++ b/src/interactivity/policy.ts
@@ -1,0 +1,38 @@
+import { VisualConstants } from '../visual-constants';
+
+/** Interaction categories an author can suppress via `data-hc-suppress`. */
+export type InteractionToken = 'filter' | 'context-menu' | 'tooltip';
+
+/**
+ * Whether a given interaction is allowed for `node`. Walks from `node` up the
+ * parent chain; if any ancestor's `data-hc-suppress` attribute names `token`
+ * (or the `all` wildcard), the interaction is suppressed.
+ *
+ * No boundary is tracked — `data-hc-suppress` only ever appears inside author
+ * content, so walking to the document root is safe.
+ *
+ * @param node  - the event target (or any element to test)
+ * @param token - the interaction category
+ * @returns true when allowed (default), false when suppressed
+ */
+export function resolveInteractivity(
+    node: Element | null,
+    token: InteractionToken
+): boolean {
+    const { suppressAttr, suppressAllToken } = VisualConstants.dom;
+    let el: Element | null = node;
+    while (el) {
+        const raw = el.getAttribute(suppressAttr);
+        if (raw) {
+            // ponytail: linear parent-chain walk, called per click and per
+            // mousemove. Fine at normal DOM depth; memoise only if a profiler on
+            // multi-MB content complains.
+            const tokens = raw.split(/\s+/);
+            if (tokens.includes(token) || tokens.includes(suppressAllToken)) {
+                return false;
+            }
+        }
+        el = el.parentElement;
+    }
+    return true;
+}

--- a/src/interactivity/policy.ts
+++ b/src/interactivity/policy.ts
@@ -1,7 +1,7 @@
 import { VisualConstants } from '../visual-constants';
 
 /** Interaction categories an author can suppress via `data-hc-suppress`. */
-export type InteractionToken = 'filter' | 'context-menu' | 'tooltip';
+type InteractionToken = 'filter' | 'context-menu' | 'tooltip';
 
 /**
  * Whether a given interaction is allowed for `node`. Walks from `node` up the

--- a/src/interactivity/tooltips.ts
+++ b/src/interactivity/tooltips.ts
@@ -127,7 +127,15 @@ function bindStandardTooltips(
 ) {
     const { tooltipService } = host;
     dataElements.on('mouseover mousemove', (event, d) => {
-        if (tooltipSuppressed(event, tooltipService)) return;
+        if (tooltipSuppressed(event, tooltipService)) {
+            // Entering a suppressed descendant: also clear the row's hover state
+            // now — mouseout won't fire until the pointer leaves the whole row.
+            select(event.currentTarget).classed(
+                VisualConstants.dom.hoverClassSelector,
+                false
+            );
+            return;
+        }
         select(event.currentTarget).classed(
             VisualConstants.dom.hoverClassSelector,
             true

--- a/src/interactivity/tooltips.ts
+++ b/src/interactivity/tooltips.ts
@@ -1,0 +1,141 @@
+// Power BI API Dependencies
+import powerbi from 'powerbi-visuals-api';
+import IVisualHost = powerbi.extensibility.visual.IVisualHost;
+import TooltipShowOptions = powerbi.extensibility.TooltipShowOptions;
+import VisualTooltipDataItem = powerbi.extensibility.VisualTooltipDataItem;
+
+// External dependencies
+import { select, Selection } from 'd3-selection';
+
+// Internal dependencies
+import { VisualConstants } from '../visual-constants';
+import { IHtmlEntry } from '../view-model';
+import { recordTooltipEvent } from '../diagnostics/event-recorder';
+import { tooltipContext, TooltipItem } from '../diagnostics/host-events';
+
+/**
+ * Handle eventing when a data element is hovred over. This includes showing
+ * the tooltip and toggling appropriate class names for style hooks.
+ *
+ * @param dataElements      - The elements to analyse and process.
+ * @param host              - Visual host services.
+ * @param hasGranularity    - Whether we have granularity or not.
+ */
+export function resolveHover(
+    dataElements: Selection<any, IHtmlEntry, any, any>,
+    host: IVisualHost,
+    hasGranularity: boolean
+) {
+    bindStandardTooltips(dataElements, host, hasGranularity);
+    bindManualTooltips(dataElements, host);
+}
+
+/**
+ * If we don't have any granularity, we will look for elements that have
+ * a tooltip attribute and use this to show the tooltip.
+ *
+ * @param dataElements      - The elements to analyse and process.
+ * @param host              - Visual host services.
+ */
+function bindManualTooltips(
+    dataElements: Selection<any, IHtmlEntry, any, any>,
+    host: IVisualHost
+) {
+    const { tooltipService } = host;
+    const {
+        manualTooltipSelector,
+        manualTooltipDataPrefix,
+        manualTooltipDataTitle,
+        manualTooltipDataValue
+    } = VisualConstants.dom;
+    const manualTooltipElements = dataElements.selectAll(
+        `.${manualTooltipSelector}`
+    );
+    const titleExp = new RegExp(
+        `${manualTooltipDataPrefix}${manualTooltipDataTitle}`,
+        'g'
+    );
+    const valueExp = new RegExp(
+        `${manualTooltipDataPrefix}${manualTooltipDataValue}`,
+        'g'
+    );
+    manualTooltipElements.on('mouseover mousemove', (event) => {
+        const dataset = event.currentTarget.dataset;
+        const keys = Object.keys(dataset).map((key) =>
+            key.replace(titleExp, '').replace(valueExp, '')
+        );
+        const uniqueKeys = [...new Set(keys)];
+        const dataItems: VisualTooltipDataItem[] = uniqueKeys.map((key) => ({
+            displayName:
+                dataset[
+                    `${manualTooltipDataPrefix}${manualTooltipDataTitle}${key}`
+                ] || '',
+            value:
+                dataset[
+                    `${manualTooltipDataPrefix}${manualTooltipDataValue}${key}`
+                ] || ''
+        }));
+        if (dataItems.length > 0) {
+            const options: TooltipShowOptions = {
+                coordinates: [event.clientX, event.clientY],
+                isTouchEvent: true,
+                dataItems,
+                identities: []
+            };
+            tooltipService.show(options);
+            recordTooltipEvent(
+                'show',
+                'manual',
+                tooltipContext(dataItems as TooltipItem[])
+            );
+        }
+    });
+    manualTooltipElements.on('mouseout', () => {
+        tooltipService.hide({ immediately: true, isTouchEvent: true });
+        recordTooltipEvent('hide', 'manual', '');
+    });
+}
+
+/**
+ * For standard data elements, working with the data roles and correct
+ * rules, we will apply the regular tooltip handling.
+ *
+ * @param dataElements      - The elements to analyse and process.
+ * @param host              - Visual host services.
+ * @param hasGranularity    - Whether we have granularity or not.
+ */
+function bindStandardTooltips(
+    dataElements: Selection<any, IHtmlEntry, any, any>,
+    host: IVisualHost,
+    hasGranularity: boolean
+) {
+    const { tooltipService } = host;
+    dataElements.on('mouseover mousemove', (event, d) => {
+        select(event.currentTarget).classed(
+            VisualConstants.dom.hoverClassSelector,
+            true
+        );
+        if (hasGranularity || d.tooltips.length > 0) {
+            const options: TooltipShowOptions = {
+                coordinates: [event.clientX, event.clientY],
+                isTouchEvent: true,
+                dataItems: d.tooltips,
+                identities: [d.identity]
+            };
+            tooltipService.show(options);
+            recordTooltipEvent(
+                'show',
+                'contextual',
+                tooltipContext(d.tooltips as TooltipItem[])
+            );
+        }
+    });
+    dataElements.on('mouseout', (event) => {
+        select(event.currentTarget).classed(
+            VisualConstants.dom.hoverClassSelector,
+            false
+        );
+        tooltipService.hide({ immediately: true, isTouchEvent: true });
+        recordTooltipEvent('hide', 'contextual', '');
+    });
+}

--- a/src/interactivity/tooltips.ts
+++ b/src/interactivity/tooltips.ts
@@ -12,6 +12,7 @@ import { VisualConstants } from '../visual-constants';
 import { IHtmlEntry } from '../view-model';
 import { recordTooltipEvent } from '../diagnostics/event-recorder';
 import { tooltipContext, TooltipItem } from '../diagnostics/host-events';
+import { resolveInteractivity } from './policy';
 
 /**
  * Handle eventing when a data element is hovred over. This includes showing
@@ -60,6 +61,10 @@ function bindManualTooltips(
         'g'
     );
     manualTooltipElements.on('mouseover mousemove', (event) => {
+        if (!resolveInteractivity(event.target as Element | null, 'tooltip')) {
+            tooltipService.hide({ immediately: true, isTouchEvent: true });
+            return;
+        }
         const dataset = event.currentTarget.dataset;
         const keys = Object.keys(dataset).map((key) =>
             key.replace(titleExp, '').replace(valueExp, '')
@@ -111,6 +116,10 @@ function bindStandardTooltips(
 ) {
     const { tooltipService } = host;
     dataElements.on('mouseover mousemove', (event, d) => {
+        if (!resolveInteractivity(event.target as Element | null, 'tooltip')) {
+            tooltipService.hide({ immediately: true, isTouchEvent: true });
+            return;
+        }
         select(event.currentTarget).classed(
             VisualConstants.dom.hoverClassSelector,
             true

--- a/src/interactivity/tooltips.ts
+++ b/src/interactivity/tooltips.ts
@@ -32,6 +32,26 @@ export function resolveHover(
 }
 
 /**
+ * Shared guard for the tooltip handlers: when the hovered target sits under a
+ * `data-hc-suppress` (tooltip / all) subtree, hide any active tooltip and report
+ * suppressed so the caller bails out before showing one.
+ *
+ * @param event          - the hover event (its `target` is walked for suppression)
+ * @param tooltipService - host tooltip service used to dismiss any active tooltip
+ * @returns true when suppressed (caller should return), false to proceed
+ */
+function tooltipSuppressed(
+    event: Event,
+    tooltipService: IVisualHost['tooltipService']
+): boolean {
+    if (resolveInteractivity(event.target as Element | null, 'tooltip')) {
+        return false;
+    }
+    tooltipService.hide({ immediately: true, isTouchEvent: true });
+    return true;
+}
+
+/**
  * If we don't have any granularity, we will look for elements that have
  * a tooltip attribute and use this to show the tooltip.
  *
@@ -61,10 +81,7 @@ function bindManualTooltips(
         'g'
     );
     manualTooltipElements.on('mouseover mousemove', (event) => {
-        if (!resolveInteractivity(event.target as Element | null, 'tooltip')) {
-            tooltipService.hide({ immediately: true, isTouchEvent: true });
-            return;
-        }
+        if (tooltipSuppressed(event, tooltipService)) return;
         const dataset = event.currentTarget.dataset;
         const keys = Object.keys(dataset).map((key) =>
             key.replace(titleExp, '').replace(valueExp, '')
@@ -116,10 +133,7 @@ function bindStandardTooltips(
 ) {
     const { tooltipService } = host;
     dataElements.on('mouseover mousemove', (event, d) => {
-        if (!resolveInteractivity(event.target as Element | null, 'tooltip')) {
-            tooltipService.hide({ immediately: true, isTouchEvent: true });
-            return;
-        }
+        if (tooltipSuppressed(event, tooltipService)) return;
         select(event.currentTarget).classed(
             VisualConstants.dom.hoverClassSelector,
             true

--- a/src/interactivity/tooltips.ts
+++ b/src/interactivity/tooltips.ts
@@ -31,15 +31,9 @@ export function resolveHover(
     bindManualTooltips(dataElements, host);
 }
 
-/**
- * Shared guard for the tooltip handlers: when the hovered target sits under a
- * `data-hc-suppress` (tooltip / all) subtree, hide any active tooltip and report
- * suppressed so the caller bails out before showing one.
- *
- * @param event          - the hover event (its `target` is walked for suppression)
- * @param tooltipService - host tooltip service used to dismiss any active tooltip
- * @returns true when suppressed (caller should return), false to proceed
- */
+// Shared tooltip-handler guard: if the hovered target is under a
+// `data-hc-suppress` (tooltip/all) subtree, hide any active tooltip and return
+// true so the caller bails before showing one.
 function tooltipSuppressed(
     event: Event,
     tooltipService: IVisualHost['tooltipService']

--- a/src/visual-constants.ts
+++ b/src/visual-constants.ts
@@ -260,7 +260,14 @@ export const VisualConstants = {
         // A persistent invisible anchor comment with the same value is left at
         // the slot after sanitization for row insertion. NOT the user-facing
         // token — purely an implementation detail of slot resolution.
-        contentSlotMarker: 'HC:CONTENT'
+        contentSlotMarker: 'HC:CONTENT',
+        // Declarative interactivity suppression. An author adds
+        // data-hc-suppress="filter context-menu tooltip" (or "all") to a node to
+        // make it + its descendants inert to the visual's cross-filter / context
+        // menu / tooltip handling, deferring to their own / native behaviour.
+        // Works in every edition because the visual reads the markup itself.
+        suppressAttr: 'data-hc-suppress',
+        suppressAllToken: 'all'
     },
     diagnostics: {
         dialogId: 'DiagnosticsDialog',

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -27,7 +27,6 @@ import { ViewModelHandler, IHtmlEntry, IViewModel } from './view-model';
 import {
     getParsedHtmlAsDom,
     resolveForRawHtml,
-    resolveHyperlinkHandling,
     resolveScrollableContent,
     resolveStyling,
     resolveTemplateContainer,
@@ -41,7 +40,8 @@ import { LandingPageHandler } from './landing';
 import {
     BehaviorManager,
     IHtmlBehaviorOptions,
-    resolveHover
+    resolveHover,
+    resolveHyperlinkHandling
 } from './interactivity';
 import { RenderFormat } from './types';
 import { sanitizerEnabled } from './sanitize';

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -39,7 +39,7 @@ import {
     getDiagnosticsRawHtml
 } from './domain-utils';
 import { LandingPageHandler } from './landing';
-import { BehaviorManager, IHtmlBehaviorOptions } from './behavior';
+import { BehaviorManager, IHtmlBehaviorOptions } from './interactivity';
 import { RenderFormat } from './types';
 import { sanitizerEnabled } from './sanitize';
 import { RenderOrchestrator, RenderSteps } from './render-orchestrator';

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -30,7 +30,6 @@ import {
     resolveHyperlinkHandling,
     resolveScrollableContent,
     resolveStyling,
-    resolveHover,
     resolveTemplateContainer,
     renderTemplatedEntries,
     reconcileTemplatedEntries,
@@ -39,7 +38,11 @@ import {
     getDiagnosticsRawHtml
 } from './domain-utils';
 import { LandingPageHandler } from './landing';
-import { BehaviorManager, IHtmlBehaviorOptions } from './interactivity';
+import {
+    BehaviorManager,
+    IHtmlBehaviorOptions,
+    resolveHover
+} from './interactivity';
 import { RenderFormat } from './types';
 import { sanitizerEnabled } from './sanitize';
 import { RenderOrchestrator, RenderSteps } from './render-orchestrator';

--- a/test/behavior.test.ts
+++ b/test/behavior.test.ts
@@ -318,3 +318,71 @@ describe('host-event instrumentation in behavior', () => {
         ).toBe(true);
     });
 });
+
+describe('interactivity suppression in behavior', () => {
+    it('suppresses cross-filter when the target is under data-hc-suppress=filter', () => {
+        const mgr = new BehaviorManager<any>();
+        const { options } = makeOptions(vi.fn());
+        const handler = { handleSelection: vi.fn(), handleContextMenu: vi.fn(), handleClearSelection: vi.fn() };
+        mgr.bindEvents(options as any, handler as any);
+
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'filter');
+        const inner = document.createElement('button');
+        modal.appendChild(inner);
+
+        const evt = { preventDefault: vi.fn(), stopPropagation: vi.fn(), ctrlKey: false, target: inner } as any;
+        mgr.handleSelectionClick(evt, { tooltips: [] } as any);
+
+        expect(evt.stopPropagation).toHaveBeenCalled(); // don't fall through to clear-catcher
+        expect(handler.handleSelection).not.toHaveBeenCalled();
+    });
+
+    it('still cross-filters when the target is outside any suppressed subtree', () => {
+        const mgr = new BehaviorManager<any>();
+        const { options } = makeOptions(vi.fn());
+        const handler = { handleSelection: vi.fn(), handleContextMenu: vi.fn(), handleClearSelection: vi.fn() };
+        mgr.bindEvents(options as any, handler as any);
+
+        const inner = document.createElement('button'); // no suppressing ancestor
+        const evt = { preventDefault: vi.fn(), stopPropagation: vi.fn(), ctrlKey: false, target: inner } as any;
+        mgr.handleSelectionClick(evt, { tooltips: [] } as any);
+
+        expect(handler.handleSelection).toHaveBeenCalled();
+    });
+
+    it('shows no context menu (but preventDefaults) under data-hc-suppress=all', () => {
+        const mgr = new BehaviorManager<any>();
+        const { options } = makeOptions(vi.fn());
+        const handler = { handleSelection: vi.fn(), handleContextMenu: vi.fn(), handleClearSelection: vi.fn() };
+        mgr.bindEvents(options as any, handler as any);
+
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'all');
+        const inner = document.createElement('span');
+        modal.appendChild(inner);
+
+        const evt = { preventDefault: vi.fn(), stopPropagation: vi.fn(), clientX: 1, clientY: 2, target: inner } as any;
+        mgr.handleContextMenu(evt, { tooltips: [] } as any);
+
+        expect(evt.preventDefault).toHaveBeenCalled(); // swallow the native browser menu too
+        expect(handler.handleContextMenu).not.toHaveBeenCalled();
+    });
+
+    it('skips the clear-catcher clear when the target is under data-hc-suppress=filter', () => {
+        const mgr = new BehaviorManager<any>();
+        const { options, clear } = makeOptions(vi.fn());
+        const handler = { handleSelection: vi.fn(), handleContextMenu: vi.fn(), handleClearSelection: vi.fn() };
+        mgr.bindEvents(options as any, handler as any);
+
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'filter');
+        const inner = document.createElement('div');
+        modal.appendChild(inner);
+
+        const clickCall = (clear.on as any).mock.calls.find((c: any[]) => c[0] === 'click');
+        clickCall[1]({ preventDefault: vi.fn(), stopPropagation: vi.fn(), target: inner });
+
+        expect(handler.handleClearSelection).not.toHaveBeenCalled();
+    });
+});

--- a/test/behavior.test.ts
+++ b/test/behavior.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BehaviorManager } from '../src/behavior';
+import { BehaviorManager } from '../src/interactivity';
 import { IViewModel, IHtmlEntry } from '../src/view-model';
 import { VisualConstants } from '../src/visual-constants';
 import { setArmed, snapshot, resetForTests } from '../src/diagnostics/event-recorder';

--- a/test/behavior.test.ts
+++ b/test/behavior.test.ts
@@ -366,6 +366,7 @@ describe('interactivity suppression in behavior', () => {
         mgr.handleContextMenu(evt, { tooltips: [] } as any);
 
         expect(evt.preventDefault).toHaveBeenCalled(); // swallow the native browser menu too
+        expect(evt.stopPropagation).toHaveBeenCalled(); // don't bubble to clear-catcher / host
         expect(handler.handleContextMenu).not.toHaveBeenCalled();
     });
 

--- a/test/domain-utils.test.ts
+++ b/test/domain-utils.test.ts
@@ -13,9 +13,9 @@ import {
     renderTemplatedEntries,
     reconcileTemplatedEntries,
     resolveForRawHtml,
-    getDiagnosticsRawHtml,
-    resolveHover
+    getDiagnosticsRawHtml
 } from '../src/domain-utils';
+import { resolveHover } from '../src/interactivity';
 import {
     setArmed,
     snapshot as evtSnapshot,

--- a/test/domain-utils.test.ts
+++ b/test/domain-utils.test.ts
@@ -5,7 +5,6 @@ import {
     bindVisualDataToDom,
     domSerialize,
     getRawHtml,
-    resolveHyperlinkHandling,
     resolveHtmlGroupElement,
     reconcileVisualDataToDom,
     stampRenderedContent,
@@ -15,7 +14,7 @@ import {
     resolveForRawHtml,
     getDiagnosticsRawHtml
 } from '../src/domain-utils';
-import { resolveHover } from '../src/interactivity';
+import { resolveHover, resolveHyperlinkHandling } from '../src/interactivity';
 import {
     setArmed,
     snapshot as evtSnapshot,

--- a/test/interactivity-policy.test.ts
+++ b/test/interactivity-policy.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { resolveInteractivity } from '../src/interactivity';
+
+// Build <root><mid [attr]><leaf></leaf></mid></root> and return leaf.
+function tree(attr?: string): Element {
+    const root = document.createElement('div');
+    const mid = document.createElement('div');
+    if (attr !== undefined) mid.setAttribute('data-hc-suppress', attr);
+    const leaf = document.createElement('span');
+    mid.appendChild(leaf);
+    root.appendChild(mid);
+    return leaf;
+}
+
+describe('resolveInteractivity', () => {
+    it('allows everything when no ancestor suppresses', () => {
+        const leaf = tree();
+        expect(resolveInteractivity(leaf, 'filter')).toBe(true);
+        expect(resolveInteractivity(leaf, 'tooltip')).toBe(true);
+        expect(resolveInteractivity(leaf, 'context-menu')).toBe(true);
+    });
+
+    it('suppresses only the named token', () => {
+        const leaf = tree('filter');
+        expect(resolveInteractivity(leaf, 'filter')).toBe(false);
+        expect(resolveInteractivity(leaf, 'tooltip')).toBe(true);
+    });
+
+    it('"all" suppresses every token', () => {
+        const leaf = tree('all');
+        expect(resolveInteractivity(leaf, 'filter')).toBe(false);
+        expect(resolveInteractivity(leaf, 'tooltip')).toBe(false);
+        expect(resolveInteractivity(leaf, 'context-menu')).toBe(false);
+    });
+
+    it('reads multiple space-separated tokens', () => {
+        const leaf = tree('filter tooltip');
+        expect(resolveInteractivity(leaf, 'filter')).toBe(false);
+        expect(resolveInteractivity(leaf, 'tooltip')).toBe(false);
+        expect(resolveInteractivity(leaf, 'context-menu')).toBe(true);
+    });
+
+    it('inherits suppression from an ancestor (descendants included)', () => {
+        const leaf = tree('all'); // attr on mid, query the leaf below it
+        expect(resolveInteractivity(leaf, 'filter')).toBe(false);
+    });
+
+    it('ignores unknown tokens', () => {
+        const leaf = tree('foo bar');
+        expect(resolveInteractivity(leaf, 'filter')).toBe(true);
+    });
+
+    it('treats a null node as allowed', () => {
+        expect(resolveInteractivity(null, 'filter')).toBe(true);
+    });
+});

--- a/test/interactivity-tooltips-suppress.test.ts
+++ b/test/interactivity-tooltips-suppress.test.ts
@@ -1,14 +1,22 @@
 import { describe, it, expect, vi } from 'vitest';
 import { resolveHover } from '../src/interactivity';
+import { VisualConstants } from '../src/visual-constants';
 
 function makeHost() {
     return { tooltipService: { show: vi.fn(), hide: vi.fn() } } as any;
 }
 
-// Mock d3 selection that captures bound handlers and stubs selectAll.
+// Mock d3 selection that captures handlers bound on the row selection AND on the
+// `.selectAll(...)` result (where bindManualTooltips binds its handler).
 function makeDataElements() {
     const handlers: Record<string, (e: any, d: any) => void> = {};
-    const manual = { on: vi.fn().mockReturnThis() };
+    const manualHandlers: Record<string, (e: any) => void> = {};
+    const manual: any = {
+        on: vi.fn((evt: string, cb: any) => {
+            manualHandlers[evt] = cb;
+            return manual;
+        })
+    };
     const sel: any = {
         on: vi.fn((evt: string, cb: any) => {
             handlers[evt] = cb;
@@ -16,7 +24,7 @@ function makeDataElements() {
         }),
         selectAll: vi.fn(() => manual)
     };
-    return { sel, handlers };
+    return { sel, handlers, manualHandlers };
 }
 
 describe('contextual tooltip suppression', () => {
@@ -31,6 +39,8 @@ describe('contextual tooltip suppression', () => {
         const inner = document.createElement('span');
         modal.appendChild(inner);
         row.appendChild(modal);
+        // Simulate a prior non-suppressed mousemove having marked the row hovered.
+        row.classList.add(VisualConstants.dom.hoverClassSelector);
 
         handlers['mouseover mousemove'](
             { target: inner, currentTarget: row, clientX: 0, clientY: 0 },
@@ -39,6 +49,10 @@ describe('contextual tooltip suppression', () => {
 
         expect(host.tooltipService.hide).toHaveBeenCalled();
         expect(host.tooltipService.show).not.toHaveBeenCalled();
+        // Hover state cleared immediately on entering the suppressed subtree.
+        expect(
+            row.classList.contains(VisualConstants.dom.hoverClassSelector)
+        ).toBe(false);
     });
 
     it('still shows the tooltip outside any suppressed subtree', () => {
@@ -56,5 +70,23 @@ describe('contextual tooltip suppression', () => {
         );
 
         expect(host.tooltipService.show).toHaveBeenCalled();
+    });
+
+    it('manual tooltips also hide over a suppressed subtree', () => {
+        const { sel, manualHandlers } = makeDataElements();
+        const host = makeHost();
+        resolveHover(sel, host, false);
+
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'all');
+        const inner = document.createElement('span');
+        modal.appendChild(inner);
+
+        // bindManualTooltips' handler takes only the event; currentTarget.dataset
+        // is never read because the suppression guard returns first.
+        manualHandlers['mouseover mousemove']({ target: inner, currentTarget: inner });
+
+        expect(host.tooltipService.hide).toHaveBeenCalled();
+        expect(host.tooltipService.show).not.toHaveBeenCalled();
     });
 });

--- a/test/interactivity-tooltips-suppress.test.ts
+++ b/test/interactivity-tooltips-suppress.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveHover } from '../src/interactivity';
+
+function makeHost() {
+    return { tooltipService: { show: vi.fn(), hide: vi.fn() } } as any;
+}
+
+// Mock d3 selection that captures bound handlers and stubs selectAll.
+function makeDataElements() {
+    const handlers: Record<string, (e: any, d: any) => void> = {};
+    const manual = { on: vi.fn().mockReturnThis() };
+    const sel: any = {
+        on: vi.fn((evt: string, cb: any) => {
+            handlers[evt] = cb;
+            return sel;
+        }),
+        selectAll: vi.fn(() => manual)
+    };
+    return { sel, handlers };
+}
+
+describe('contextual tooltip suppression', () => {
+    it('hides instead of showing over a data-hc-suppress=tooltip subtree', () => {
+        const { sel, handlers } = makeDataElements();
+        const host = makeHost();
+        resolveHover(sel, host, false);
+
+        const row = document.createElement('div');
+        const modal = document.createElement('div');
+        modal.setAttribute('data-hc-suppress', 'tooltip');
+        const inner = document.createElement('span');
+        modal.appendChild(inner);
+        row.appendChild(modal);
+
+        handlers['mouseover mousemove'](
+            { target: inner, currentTarget: row, clientX: 0, clientY: 0 },
+            { tooltips: [{ displayName: 'x', value: 'y' }], identity: {} }
+        );
+
+        expect(host.tooltipService.hide).toHaveBeenCalled();
+        expect(host.tooltipService.show).not.toHaveBeenCalled();
+    });
+
+    it('still shows the tooltip outside any suppressed subtree', () => {
+        const { sel, handlers } = makeDataElements();
+        const host = makeHost();
+        resolveHover(sel, host, false);
+
+        const row = document.createElement('div');
+        const inner = document.createElement('span');
+        row.appendChild(inner);
+
+        handlers['mouseover mousemove'](
+            { target: inner, currentTarget: row, clientX: 0, clientY: 0 },
+            { tooltips: [{ displayName: 'x', value: 'y' }], identity: {} }
+        );
+
+        expect(host.tooltipService.show).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Why

Reviewer feedback on the Team Cards sample (issue #127): with a per-row **modal dialog**, clicking anywhere on the modal cross-filtered the source card, and the card's tooltip appeared over the modal. Root cause: the modal is nested inside the row's selectable element, so it inherits the row's click/context-menu/tooltip handling. The author's only workaround was hand-written `event.stopPropagation()`, which doesn't exist in the certified (no-scripting) edition.

## What

**A declarative, markup-only way to make a node + its descendants inert to the visual's interactivity** — works in every edition because the visual reads the attribute itself.

```html
<div class="modal-overlay" data-hc-suppress="all"> … </div>
<span class="spark" data-hc-suppress="tooltip"> … </span>
```

| Token | Suppresses |
|---|---|
| `filter` | Cross-filter (select / clear) on click |
| `context-menu` | Right-click context / drill menu |
| `tooltip` | Hover tooltip |
| `all` | All of the above |

A pure resolver (`resolveInteractivity`) walks the event target's parent chain; the existing delegated handlers consult it and bail out early when suppressed. Suppression only switches off **the visual's** handling — an author's own inline handlers and links still work. Suppressing the context menu also swallows the native browser menu. (`data-hc-force` re-enabling was scoped out — no consumer yet.)

## Refactor (bundled)

The interactivity code was scattered across `behavior.ts` and the `domain-utils.ts` grab-bag. This consolidates it into a focused **`src/interactivity/`** surface behind a barrel — all behaviour-preserving, suite green after each step:

- `behavior.ts` (moved), `tooltips.ts` + `hyperlinks.ts` (extracted from `domain-utils`), `policy.ts` (new), `index.ts` (barrel).
- `domain-utils.ts` shed 182 lines of interactivity code.

## Testing

`961 passed, 0 failed` (certified edition). New unit tests for the resolver, behavior suppression (filter / context-menu / clear-catcher), and tooltip suppression.

## Notes

- Design records included under `docs/brainstorms/` + `docs/plans/`.
- Author-facing docs (`docs/v2/`) and the Team Cards UAT sample (`sample-for-templates/`) are maintained as untracked working assets and are intentionally **not** part of this PR. A lighter, committable UAT corpus for the feature is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
