### PR TITLE
fix: cross-filtering requires a column in the Context role

### DIFF
--- a/docs/plans/2026-08-04-crossfilter-requires-context-column.md
+++ b/docs/plans/2026-08-04-crossfilter-requires-context-column.md
@@ -1,0 +1,349 @@
+# Cross-Filter Requires a Column in Context — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cross-filtering (both the behavior and the format-pane card) is only enabled when the Context data role contains at least one **column** — measures alone don't count, because selecting by measure identity cross-filters nothing useful.
+
+**Architecture:** The Context role's internal name is `sampling` (renamed to "Context" in the UI, PR #182), and it accepts `GroupingOrMeasure`. Today `hasGranularity = columns.some((c) => c.roles?.sampling)` in `src/view-model.ts` gates three things: the `hasCrossFiltering` flag (which `src/interactivity/behavior.ts` consumes), the cross-filter card visibility in `src/visual-settings.ts`, and tooltip/hover binding in `src/interactivity/tooltips.ts`. Tooltips and hover are still correct for measures in Context, so `hasGranularity` keeps its meaning untouched. We add a new view-model flag `hasContextColumns` (`sampling` role AND `!isMeasure` — measure metadata columns carry `isMeasure: true`, category columns don't) and switch only the two cross-filter consumers to it. `behavior.ts` needs no change; it already reads `hasCrossFiltering`.
+
+**Tech Stack:** TypeScript Power BI custom visual; tests are Vitest (`npm test` runs `vitest run`; a `pretest` hook runs `select-edition.mjs certified` — that's expected noise, not an error).
+
+**Plan location note:** Saved to `docs/plans/` per this repo's convention (not the superpowers default path).
+
+---
+
+### Task 1: `hasContextColumns` flag in the view model
+
+**Files:**
+- Modify: `src/view-model.ts` (interface ~line 25, `reset()` ~line 74, `mapDataView()` ~line 137)
+- Test: `test/view-model.test.ts`
+- Modify: `test/visual-settings.test.ts` (mock object typed as `IViewModel` — needs the new required field to stay type-correct)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/view-model.test.ts`, inside the `describe('mapDataView', ...)` block (after the existing test `'should set hasCrossFiltering when enabled in settings'`, ~line 475), add:
+
+```ts
+        it('should not enable cross-filtering when Context holds only measures', () => {
+            const settingsWithCrossFilter = {
+                ...mockSettings,
+                crossFilter: {
+                    crossFilterCardMain: {
+                        enabled: { value: true }
+                    }
+                }
+            } as any;
+
+            const dataViews: any[] = [
+                {
+                    metadata: {
+                        columns: [
+                            {
+                                roles: { sampling: true },
+                                displayName: 'Sales',
+                                queryName: 'qm',
+                                isMeasure: true
+                            },
+                            {
+                                roles: { content: true },
+                                displayName: 'HTML',
+                                queryName: 'q0'
+                            }
+                        ]
+                    },
+                    categorical: {
+                        values: [
+                            {
+                                source: {
+                                    roles: { sampling: true },
+                                    displayName: 'Sales',
+                                    queryName: 'qm',
+                                    isMeasure: true
+                                },
+                                values: [100]
+                            },
+                            {
+                                source: {
+                                    roles: { content: true },
+                                    displayName: 'HTML',
+                                    queryName: 'q0'
+                                },
+                                values: ['<p>Test</p>']
+                            }
+                        ]
+                    }
+                }
+            ];
+
+            handler.validateDataView(dataViews);
+            handler.mapDataView(
+                dataViews,
+                settingsWithCrossFilter,
+                mockHost,
+                true
+            );
+
+            // Measures in Context still count as granularity (tooltips/hover)…
+            expect(handler.viewModel.hasGranularity).toBe(true);
+            // …but must not enable cross-filtering.
+            expect(handler.viewModel.hasContextColumns).toBe(false);
+            expect(handler.viewModel.hasCrossFiltering).toBe(false);
+        });
+
+        it('should set hasContextColumns when Context holds a column, even alongside a measure', () => {
+            const settingsWithCrossFilter = {
+                ...mockSettings,
+                crossFilter: {
+                    crossFilterCardMain: {
+                        enabled: { value: true }
+                    }
+                }
+            } as any;
+
+            const dataViews: any[] = [
+                {
+                    metadata: {
+                        columns: [
+                            {
+                                roles: { sampling: true },
+                                displayName: 'Category',
+                                queryName: 'qs'
+                            },
+                            {
+                                roles: { sampling: true },
+                                displayName: 'Sales',
+                                queryName: 'qm',
+                                isMeasure: true
+                            },
+                            {
+                                roles: { content: true },
+                                displayName: 'HTML',
+                                queryName: 'q0'
+                            }
+                        ]
+                    },
+                    categorical: {
+                        categories: [
+                            {
+                                source: {
+                                    roles: { sampling: true },
+                                    displayName: 'Category',
+                                    queryName: 'qs'
+                                },
+                                values: ['A']
+                            }
+                        ],
+                        values: [
+                            {
+                                source: {
+                                    roles: { sampling: true },
+                                    displayName: 'Sales',
+                                    queryName: 'qm',
+                                    isMeasure: true
+                                },
+                                values: [100]
+                            },
+                            {
+                                source: {
+                                    roles: { content: true },
+                                    displayName: 'HTML',
+                                    queryName: 'q0'
+                                },
+                                values: ['<p>Test</p>']
+                            }
+                        ]
+                    }
+                }
+            ];
+
+            handler.validateDataView(dataViews);
+            handler.mapDataView(
+                dataViews,
+                settingsWithCrossFilter,
+                mockHost,
+                true
+            );
+
+            expect(handler.viewModel.hasContextColumns).toBe(true);
+            expect(handler.viewModel.hasCrossFiltering).toBe(true);
+        });
+```
+
+Also extend the first test in `describe('constructor and reset', ...)` (~line 12, `'should initialize with default view model'`): after the line `expect(handler.viewModel.hasGranularity).toBe(false);` add:
+
+```ts
+            expect(handler.viewModel.hasContextColumns).toBe(false);
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- test/view-model.test.ts`
+Expected: the two new `mapDataView` tests FAIL — `hasContextColumns` is `undefined`, so `expect(...).toBe(false)` fails in the measure-only test (and `.toBe(true)` fails in the column test). The `hasCrossFiltering` assertion in the measure-only test also fails (currently `true`). The extended init test fails on `undefined !== false`.
+
+- [ ] **Step 3: Implement the flag in `src/view-model.ts`**
+
+Three edits.
+
+(a) In `IViewModel` (~line 28), after `hasCrossFiltering: boolean;`:
+
+```ts
+    hasCrossFiltering: boolean;
+    hasContextColumns: boolean;
+    hasGranularity: boolean;
+```
+
+(b) In `reset()` (~line 77), after `hasCrossFiltering: false,`:
+
+```ts
+            hasCrossFiltering: false,
+            hasContextColumns: false,
+            hasGranularity: false,
+```
+
+(c) In `mapDataView()` (~lines 137–140), replace:
+
+```ts
+            const hasGranularity = columns.some((c) => c.roles?.sampling);
+            const hasCrossFiltering =
+                hasGranularity &&
+                settings.crossFilter.crossFilterCardMain.enabled.value;
+```
+
+with:
+
+```ts
+            const hasGranularity = columns.some((c) => c.roles?.sampling);
+            // Cross-filtering needs a column (grouping) in the Context role;
+            // measures produce no useful selection identity to filter by.
+            const hasContextColumns = columns.some(
+                (c) => c.roles?.sampling && !c.isMeasure
+            );
+            const hasCrossFiltering =
+                hasContextColumns &&
+                settings.crossFilter.crossFilterCardMain.enabled.value;
+```
+
+and further down (~line 177), alongside the other flag assignments, add:
+
+```ts
+            this.viewModel.hasCrossFiltering = hasCrossFiltering;
+            this.viewModel.hasContextColumns = hasContextColumns;
+            this.viewModel.hasGranularity = hasGranularity;
+```
+
+(d) `IViewModel` gained a required field, so the `mockViewModel` literal in `test/visual-settings.test.ts` (typed `IViewModel`, `beforeEach` ~line 13) must include it. After `hasCrossFiltering: false,` add:
+
+```ts
+            hasCrossFiltering: false,
+            hasContextColumns: false,
+            hasGranularity: false,
+```
+
+- [ ] **Step 4: Run the full test suite to verify it passes**
+
+Run: `npm test`
+Expected: PASS — all suites green, including the two new tests and the existing `'should set hasCrossFiltering when enabled in settings'` (its Context field is a category column, so it still cross-filters).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/view-model.ts test/view-model.test.ts test/visual-settings.test.ts
+git commit -m "fix: cross-filtering requires a column in the Context role"
+```
+
+---
+
+### Task 2: Format-pane card visibility follows the column-only flag
+
+**Files:**
+- Modify: `src/visual-settings.ts:42`
+- Test: `test/visual-settings.test.ts` (crossFilter visibility block, ~lines 99–170)
+
+- [ ] **Step 1: Write the failing test and retarget existing ones**
+
+In `test/visual-settings.test.ts`, inside `describe('crossFilter visibility', ...)`:
+
+(a) Add a new test after the existing `'should hide crossFilter card when hasGranularity is false'` (~line 106):
+
+```ts
+            it('should hide crossFilter card when Context holds only measures', () => {
+                mockViewModel.hasGranularity = true;
+                mockViewModel.hasContextColumns = false;
+
+                settings.handlePropertyVisibility(mockViewModel);
+
+                expect(settings.crossFilter.visible).toBe(false);
+            });
+```
+
+(b) The five existing tests in this block that set `mockViewModel.hasGranularity = true;` (~lines 108–169: `'should show useTransparency…'`, `'should hide useTransparency…'`, `'should show transparencyPercent…'`, and the two `'should hide transparencyPercent…'` tests) now exercise the column-only gate. In each, replace:
+
+```ts
+                mockViewModel.hasGranularity = true;
+```
+
+with:
+
+```ts
+                mockViewModel.hasContextColumns = true;
+```
+
+and update their names from `hasGranularity` to `hasContextColumns` (e.g. `'should show useTransparency when hasContextColumns and enabled'`).
+
+(c) Rename the first test and its setter to match the new gate:
+
+```ts
+            it('should hide crossFilter card when hasContextColumns is false', () => {
+                mockViewModel.hasContextColumns = false;
+
+                settings.handlePropertyVisibility(mockViewModel);
+
+                expect(settings.crossFilter.visible).toBe(false);
+            });
+```
+
+- [ ] **Step 2: Run the tests to verify the right ones fail**
+
+Run: `npm test -- test/visual-settings.test.ts`
+Expected: the new measure-only test FAILS (`crossFilter.visible` is `true` because the source still checks `hasGranularity`), and the five retargeted "show/hide useTransparency/transparencyPercent" tests FAIL (card is hidden because `hasGranularity` is now `false` in the mock). The two "hide when … false" tests pass.
+
+- [ ] **Step 3: Implement the visibility change**
+
+In `src/visual-settings.ts`, `handlePropertyVisibility` (~line 42), replace:
+
+```ts
+        if (viewModel.hasGranularity) {
+```
+
+with:
+
+```ts
+        if (viewModel.hasContextColumns) {
+```
+
+- [ ] **Step 4: Run the full test suite to verify it passes**
+
+Run: `npm test`
+Expected: PASS — all suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/visual-settings.ts test/visual-settings.test.ts
+git commit -m "fix: hide cross-filter card unless Context holds a column"
+```
+
+---
+
+## Out of scope (deliberate)
+
+- `hasGranularity` semantics and its consumers (`resolveHover` / tooltip binding in `src/interactivity/tooltips.ts`) are unchanged — measures in Context still produce tooltips on hover, which is correct.
+- `src/interactivity/behavior.ts` needs no change: it gates on `viewModel.hasCrossFiltering`, which Task 1 already tightens.
+- No capabilities.json, resjson string, or docs changes. If UAT shows authors are confused about why the card disappears with measures-only Context, a follow-up could add a note to the `Roles_Sampling_Description` string — not doing it speculatively.
+
+## Manual UAT (after both tasks)
+
+In Power BI Desktop with the dev visual:
+1. Context = one column → cross-filter card visible; enabling it makes row clicks cross-filter. (Existing behavior, unchanged.)
+2. Context = one measure only → cross-filter card hidden; row clicks do nothing; tooltips still show the measure value on hover.
+3. Context = column + measure → card visible and cross-filtering works.

--- a/docs/solutions/logic-errors/cross-filter-requires-context-column-not-measure-2026-08-04.md
+++ b/docs/solutions/logic-errors/cross-filter-requires-context-column-not-measure-2026-08-04.md
@@ -1,0 +1,105 @@
+---
+title: "Cross-filtering fires for measures-only Context role with no selection identity"
+date: 2026-08-04
+category: logic-errors
+module: src/view-model.ts
+problem_type: logic_error
+component: tooling
+severity: medium
+related_components:
+  - src/visual-settings.ts
+  - src/categorical-table.ts
+  - src/interactivity/tooltips.ts
+  - capabilities.json
+symptoms:
+  - "Cross-filter format-pane card appears and cross-filtering activates when the Context (sampling) role holds only measures, with no category/dimension field bound"
+  - "Clicking rendered content toggles a 'selection' state that filters nothing meaningful, since only category columns contribute filterable data points to selection identities; measures contribute via withMeasure only"
+  - "No error, warning, or console output — the feature silently misbehaves rather than failing"
+root_cause: logic_error
+resolution_type: code_fix
+tags:
+  - cross-filtering
+  - context-role
+  - sampling-role
+  - selection-identity
+  - view-model
+  - measures-vs-categories
+  - format-pane
+  - data-roles
+---
+
+# Cross-filtering fires for measures-only Context role with no selection identity
+
+Fixed on branch `fix/crossfilter-context-columns`, commits `4bb0843` (view-model gate) and `40d43ad` (format-pane card visibility).
+
+## Problem
+
+Adding a measure-only field to the "Context" data role silently enabled the visual's cross-filtering UI and click handling, but clicking never actually filtered anything — the format-pane cross-filter card appeared, selection state toggled internally, yet the host received no usable selection identity to filter by.
+
+## Symptoms
+
+- Format pane showed the "Cross filtering" card as soon as any field occupied Context, including a bare measure.
+- Clicking rendered content toggled a selected/highlighted state in the visual with no corresponding cross-filter applied to the report.
+- No error, no console warning — the feature just looked live but did nothing, making it hard to tell "it's broken" from "I set it up wrong."
+
+## What Didn't Work
+
+Considered and rejected (before implementation, not after a failed attempt): tightening the existing `hasGranularity` flag itself (`columns.some((c) => c.roles?.sampling)`) to exclude measures, rather than introducing a second flag. `hasGranularity` also gates tooltip/hover binding (`resolveHover` → `bindStandardTooltips`), which is a legitimate and desired use of measures in the Context role — showing a measure's value on hover has no selection-identity requirement. Redefining `hasGranularity` to be column-only would have silently broken tooltips for every report using a measure in Context, trading one bug for a regression in a working, unrelated feature. The one-flag-many-consumers shape was itself the problem to fix, not the flag's definition.
+
+## Solution
+
+`src/view-model.ts` — added a second, narrower flag and switched the cross-filtering gate to it, leaving `hasGranularity` untouched:
+
+```ts
+// before
+const hasGranularity = columns.some((c) => c.roles?.sampling);
+const hasCrossFiltering =
+    hasGranularity &&
+    settings.crossFilter.crossFilterCardMain.enabled.value;
+
+// after
+const hasGranularity = columns.some((c) => c.roles?.sampling);
+// Cross-filtering needs a column (grouping) in the Context role;
+// measures produce no useful selection identity to filter by.
+const hasContextColumns = columns.some(
+    (c) => c.roles?.sampling && !c.isMeasure
+);
+const hasCrossFiltering =
+    hasContextColumns &&
+    settings.crossFilter.crossFilterCardMain.enabled.value;
+```
+
+`hasContextColumns` was also added to `IViewModel` and to the default/reset view model state, and threaded through `mapDataView` alongside `hasGranularity`.
+
+`src/visual-settings.ts` — `handlePropertyVisibility` now hides the cross-filter card unless `hasContextColumns` is true:
+
+```ts
+// before
+if (viewModel.hasGranularity) {
+
+// after
+if (viewModel.hasContextColumns) {
+```
+
+Tests pin both behaviors (TDD: written and verified failing before the implementation change):
+
+- `test/view-model.test.ts` — `hasGranularity` is `true` but `hasContextColumns`/`hasCrossFiltering` are `false` when Context holds only a measure; `hasContextColumns` becomes `true` when a plain column is present alongside a measure in Context.
+- `test/visual-settings.test.ts` — "should hide crossFilter card when Context holds only measures" explicitly sets `hasGranularity = true` and `hasContextColumns = false`, asserting the card stays hidden — this is the regression-pinning case, since the old code (`if (viewModel.hasGranularity)`) would fail it.
+
+## Why This Works
+
+`DataViewMetadataColumn.isMeasure` is Power BI's own signal for "this field is aggregated/summarized" (true for measures and for numeric columns the host implicitly aggregates), which aligns exactly with "this field cannot contribute a *filterable* category data point." In `src/categorical-table.ts` (`mapCategoricalToTable`, ~lines 70-79), selection identities are built from both sides — `withCategory(c, i)` over `categorical.categories` and `withMeasure(v.source.queryName)` over `categorical.values` — so a measure-only Context role still yields a selectable identity (one single-aggregate-row identity, per the issue #130 rowCount-fallback rule), but that identity carries no category data points, giving the host nothing to cross-filter by. So `!c.isMeasure` on a `sampling`-role column is precisely the condition filterable-identity generation depends on, making it the correct, semantically honest gate for cross-filtering rather than an incidental proxy. Splitting into two flags — `hasGranularity` (any field, drives tooltips) and `hasContextColumns` (column only, drives cross-filtering and its format-pane visibility) — lets each consumer keep the semantics it actually needs instead of forcing one shared boolean to satisfy both.
+
+## Prevention
+
+- When a single boolean gate is consumed by multiple features with different underlying requirements, don't retarget the shared flag to fix one consumer — split it into consumer-specific flags (`hasGranularity` vs `hasContextColumns` here) so each keeps correct semantics independently.
+- When adding any feature gated on a `GroupingOrMeasure` (or similarly dual-purpose) data role, explicitly decide and document whether measures qualify — don't assume "field present in role" is equivalent to "field usable by this feature." Check whether the feature depends on selection identity (categories only) vs. just a value (categories or measures).
+- Regression-test pattern worth reusing: assert flag A is `true` while flag B is `false` in the same test case, to pin the exact scenario a naive/old implementation would get wrong (see the "hide crossFilter card when Context holds only measures" test).
+
+## Related Issues
+
+- [report-page-tooltip-three-gate-measure-only-2026-06-12.md](../design-patterns/report-page-tooltip-three-gate-measure-only-2026-06-12.md) — sibling gating logic on the same `sampling` role, contrasting consumer semantics (any-field for tooltips vs. `isMeasure`-filtered for cross-filter)
+- [rename-data-role-sweep-all-user-facing-strings-2026-07-03.md](../conventions/rename-data-role-sweep-all-user-facing-strings-2026-07-03.md) — the Granularity→Context display-name rename (PR #182) this fix's role vocabulary depends on
+- [docs/plans/2026-08-04-crossfilter-requires-context-column.md](../../plans/2026-08-04-crossfilter-requires-context-column.md) — this fix's implementation plan
+- [docs/brainstorms/2026-06-12-categorical-data-mapping-selection-ids.md](../../brainstorms/2026-06-12-categorical-data-mapping-selection-ids.md) and [docs/plans/2026-06-12-001-categorical-data-mapping-selection-ids-plan.md](../../plans/2026-06-12-001-categorical-data-mapping-selection-ids-plan.md) — origin of `hasGranularity` and the categorical `isMeasure` metadata this fix builds on
+- GitHub issue #4 (closed) — historical origin of the `sampling` data role; no open issue reported this bug (caught proactively during cross-filter UAT)

--- a/src/view-model.ts
+++ b/src/view-model.ts
@@ -26,6 +26,7 @@ export interface IViewModel {
     isValid: boolean;
     isEmpty: boolean;
     hasCrossFiltering: boolean;
+    hasContextColumns: boolean;
     hasGranularity: boolean;
     hasSelection: boolean;
     contentIndex: number;
@@ -75,6 +76,7 @@ export class ViewModelHandler {
             isValid: false,
             isEmpty: true,
             hasCrossFiltering: false,
+            hasContextColumns: false,
             hasGranularity: false,
             hasSelection: false,
             contentIndex: -1,
@@ -135,8 +137,13 @@ export class ViewModelHandler {
             const contentIndex = this.getContentMetadataIndex(columns);
             this.viewModel.contentIndex = contentIndex;
             const hasGranularity = columns.some((c) => c.roles?.sampling);
+            // Cross-filtering needs a column (grouping) in the Context role;
+            // measures produce no useful selection identity to filter by.
+            const hasContextColumns = columns.some(
+                (c) => c.roles?.sampling && !c.isMeasure
+            );
             const hasCrossFiltering =
-                hasGranularity &&
+                hasContextColumns &&
                 settings.crossFilter.crossFilterCardMain.enabled.value;
             // Reconciling selection via per-row equals() scans of the previous
             // entries is quadratic across updates at the row cap; a key lookup
@@ -174,6 +181,7 @@ export class ViewModelHandler {
                       })
                     : [];
             this.viewModel.hasCrossFiltering = hasCrossFiltering;
+            this.viewModel.hasContextColumns = hasContextColumns;
             this.viewModel.hasGranularity = hasGranularity;
             this.viewModel.hasSelection = hasSelection;
             this.viewModel.contentFormatting = settings.contentFormatting;

--- a/src/visual-settings.ts
+++ b/src/visual-settings.ts
@@ -39,7 +39,7 @@ export class VisualFormattingSettingsModel extends FormattingSettingsModel {
             this.contentFormatting.contentFormattingCardDefaultBodyStyling.visible = true;
         }
         // Cross-filtering properties
-        if (viewModel.hasGranularity) {
+        if (viewModel.hasContextColumns) {
             this.crossFilter.crossFilterCardMain.useTransparency.visible =
                 this.crossFilter.crossFilterCardMain.enabled.value;
             this.crossFilter.crossFilterCardMain.transparencyPercent.visible =

--- a/test/view-model.test.ts
+++ b/test/view-model.test.ts
@@ -15,6 +15,7 @@ describe('ViewModelHandler', () => {
             expect(handler.viewModel.isEmpty).toBe(true);
             expect(handler.viewModel.hasCrossFiltering).toBe(false);
             expect(handler.viewModel.hasGranularity).toBe(false);
+            expect(handler.viewModel.hasContextColumns).toBe(false);
             expect(handler.viewModel.hasSelection).toBe(false);
             expect(handler.viewModel.contentIndex).toBe(-1);
             expect(handler.viewModel.htmlEntries).toEqual([]);
@@ -471,6 +472,150 @@ describe('ViewModelHandler', () => {
             );
 
             expect(handler.viewModel.hasGranularity).toBe(true);
+            expect(handler.viewModel.hasCrossFiltering).toBe(true);
+        });
+
+        it('should not enable cross-filtering when Context holds only measures', () => {
+            const settingsWithCrossFilter = {
+                ...mockSettings,
+                crossFilter: {
+                    crossFilterCardMain: {
+                        enabled: { value: true }
+                    }
+                }
+            } as any;
+
+            const dataViews: any[] = [
+                {
+                    metadata: {
+                        columns: [
+                            {
+                                roles: { sampling: true },
+                                displayName: 'Sales',
+                                queryName: 'qm',
+                                isMeasure: true
+                            },
+                            {
+                                roles: { content: true },
+                                displayName: 'HTML',
+                                queryName: 'q0'
+                            }
+                        ]
+                    },
+                    categorical: {
+                        values: [
+                            {
+                                source: {
+                                    roles: { sampling: true },
+                                    displayName: 'Sales',
+                                    queryName: 'qm',
+                                    isMeasure: true
+                                },
+                                values: [100]
+                            },
+                            {
+                                source: {
+                                    roles: { content: true },
+                                    displayName: 'HTML',
+                                    queryName: 'q0'
+                                },
+                                values: ['<p>Test</p>']
+                            }
+                        ]
+                    }
+                }
+            ];
+
+            handler.validateDataView(dataViews);
+            handler.mapDataView(
+                dataViews,
+                settingsWithCrossFilter,
+                mockHost,
+                true
+            );
+
+            // Measures in Context still count as granularity (tooltips/hover)…
+            expect(handler.viewModel.hasGranularity).toBe(true);
+            // …but must not enable cross-filtering.
+            expect(handler.viewModel.hasContextColumns).toBe(false);
+            expect(handler.viewModel.hasCrossFiltering).toBe(false);
+        });
+
+        it('should set hasContextColumns when Context holds a column, even alongside a measure', () => {
+            const settingsWithCrossFilter = {
+                ...mockSettings,
+                crossFilter: {
+                    crossFilterCardMain: {
+                        enabled: { value: true }
+                    }
+                }
+            } as any;
+
+            const dataViews: any[] = [
+                {
+                    metadata: {
+                        columns: [
+                            {
+                                roles: { sampling: true },
+                                displayName: 'Category',
+                                queryName: 'qs'
+                            },
+                            {
+                                roles: { sampling: true },
+                                displayName: 'Sales',
+                                queryName: 'qm',
+                                isMeasure: true
+                            },
+                            {
+                                roles: { content: true },
+                                displayName: 'HTML',
+                                queryName: 'q0'
+                            }
+                        ]
+                    },
+                    categorical: {
+                        categories: [
+                            {
+                                source: {
+                                    roles: { sampling: true },
+                                    displayName: 'Category',
+                                    queryName: 'qs'
+                                },
+                                values: ['A']
+                            }
+                        ],
+                        values: [
+                            {
+                                source: {
+                                    roles: { sampling: true },
+                                    displayName: 'Sales',
+                                    queryName: 'qm',
+                                    isMeasure: true
+                                },
+                                values: [100]
+                            },
+                            {
+                                source: {
+                                    roles: { content: true },
+                                    displayName: 'HTML',
+                                    queryName: 'q0'
+                                },
+                                values: ['<p>Test</p>']
+                            }
+                        ]
+                    }
+                }
+            ];
+
+            handler.validateDataView(dataViews);
+            handler.mapDataView(
+                dataViews,
+                settingsWithCrossFilter,
+                mockHost,
+                true
+            );
+
+            expect(handler.viewModel.hasContextColumns).toBe(true);
             expect(handler.viewModel.hasCrossFiltering).toBe(true);
         });
 

--- a/test/visual-settings.test.ts
+++ b/test/visual-settings.test.ts
@@ -14,6 +14,7 @@ describe('VisualFormattingSettingsModel', () => {
             isValid: true,
             isEmpty: false,
             hasCrossFiltering: false,
+            hasContextColumns: false,
             hasGranularity: false,
             hasSelection: false,
             contentIndex: 0,

--- a/test/visual-settings.test.ts
+++ b/test/visual-settings.test.ts
@@ -98,16 +98,25 @@ describe('VisualFormattingSettingsModel', () => {
         });
 
         describe('crossFilter visibility', () => {
-            it('should hide crossFilter card when hasGranularity is false', () => {
-                mockViewModel.hasGranularity = false;
+            it('should hide crossFilter card when hasContextColumns is false', () => {
+                mockViewModel.hasContextColumns = false;
 
                 settings.handlePropertyVisibility(mockViewModel);
 
                 expect(settings.crossFilter.visible).toBe(false);
             });
 
-            it('should show useTransparency when hasGranularity and enabled', () => {
+            it('should hide crossFilter card when Context holds only measures', () => {
                 mockViewModel.hasGranularity = true;
+                mockViewModel.hasContextColumns = false;
+
+                settings.handlePropertyVisibility(mockViewModel);
+
+                expect(settings.crossFilter.visible).toBe(false);
+            });
+
+            it('should show useTransparency when hasContextColumns and enabled', () => {
+                mockViewModel.hasContextColumns = true;
                 settings.crossFilter.crossFilterCardMain.enabled.value = true;
 
                 settings.handlePropertyVisibility(mockViewModel);
@@ -118,8 +127,8 @@ describe('VisualFormattingSettingsModel', () => {
                 ).toBe(true);
             });
 
-            it('should hide useTransparency when hasGranularity but not enabled', () => {
-                mockViewModel.hasGranularity = true;
+            it('should hide useTransparency when hasContextColumns but not enabled', () => {
+                mockViewModel.hasContextColumns = true;
                 settings.crossFilter.crossFilterCardMain.enabled.value = false;
 
                 settings.handlePropertyVisibility(mockViewModel);
@@ -130,8 +139,8 @@ describe('VisualFormattingSettingsModel', () => {
                 ).toBe(false);
             });
 
-            it('should show transparencyPercent when hasGranularity, enabled, and useTransparency', () => {
-                mockViewModel.hasGranularity = true;
+            it('should show transparencyPercent when hasContextColumns, enabled, and useTransparency', () => {
+                mockViewModel.hasContextColumns = true;
                 settings.crossFilter.crossFilterCardMain.enabled.value = true;
                 settings.crossFilter.crossFilterCardMain.useTransparency.value = true;
 
@@ -144,7 +153,7 @@ describe('VisualFormattingSettingsModel', () => {
             });
 
             it('should hide transparencyPercent when enabled but useTransparency is false', () => {
-                mockViewModel.hasGranularity = true;
+                mockViewModel.hasContextColumns = true;
                 settings.crossFilter.crossFilterCardMain.enabled.value = true;
                 settings.crossFilter.crossFilterCardMain.useTransparency.value = false;
 
@@ -157,7 +166,7 @@ describe('VisualFormattingSettingsModel', () => {
             });
 
             it('should hide transparencyPercent when not enabled', () => {
-                mockViewModel.hasGranularity = true;
+                mockViewModel.hasContextColumns = true;
                 settings.crossFilter.crossFilterCardMain.enabled.value = false;
                 settings.crossFilter.crossFilterCardMain.useTransparency.value = true;
 


### PR DESCRIPTION
## Summary
- Cross-filtering (behavior + format-pane card) now requires at least one **column** in the Context data role — measures alone no longer enable it, since measures contribute no filterable category data point to selection identities.
- New view-model flag `hasContextColumns` (`roles.sampling && !isMeasure`) gates `hasCrossFiltering` and the cross-filter card visibility; `hasGranularity` keeps its any-field semantics so tooltips/hover still work for measures in Context.
- Includes the implementation plan and a `docs/solutions/` learning capturing the two-flag design rationale.

## Test Plan
- [x] Unit: measure-only Context → `hasGranularity` true, `hasContextColumns`/`hasCrossFiltering` false; column+measure → both true (test/view-model.test.ts)
- [x] Unit: cross-filter card hidden when Context holds only measures; full visibility matrix retargeted (test/visual-settings.test.ts)
- [x] Full suite green: 42 files / 1171 tests
- [x] Desktop UAT: Context = column → card visible, clicks cross-filter
- [x] Desktop UAT: Context = measure only → card hidden, clicks inert, tooltips still show the measure value
- [x] Desktop UAT: Context = column + measure → card visible, cross-filtering works

🤖 Generated with [Claude Code](https://claude.com/claude-code)